### PR TITLE
Update dev env setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ Getting started on Windows:
   - VSCode should prompt for this when you open our code.
   - Alternatively, open the "Extensions" sidebar, type `@recommended` into the
   search box, and install the items in that list.
-- Install the latest Python 3
-  - VSCode's python extension should prompt you with a button to do this.
-  - Alternatively, find it in the Windows Store: "Python 3.10"
+- Install Python 3.10
+  - Install from the python website; do not use the Windows Store version.
+  - Install 3.10, *not* 3.11, because a transitive dependency of `arcade` cannot easily
+  be installed on Windows on Python 3.11.
+  - https://www.python.org/downloads/
 - Install Python dependencies:
 
     ```
-    pip install black
-    pip install arcade
+    pip install -r requirements.txt
     ```
 
 Restart VSCode to detect installed changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# `pip install -r requirements.txt` to install python dependencies
+arcade
+mypy
+black


### PR DESCRIPTION
https://trello.com/c/jPwfiofL/36-update-dev-env-setup-instructions

Based on some new things I've learned while working on the project.  The Windows Store installation of python doesn't put `pip`-installed CLI tools on the PATH, which is a bit annoying.  This problem goes away when using the official python installer from python's website.

If/when people switch their python installation, we should probably walk through the process together.  I had to delete `C:\Python*` manually to expunge the old windows store version.
