### PR TITLE
Add config file for "Git Graph"

### DIFF
--- a/.vscode/vscode-git-graph.json
+++ b/.vscode/vscode-git-graph.json
@@ -1,0 +1,20 @@
+{
+    "issueLinkingConfig": {
+        "issue": "#(\\d+)",
+        "url": "https://github.com/CastIronChat/twisted-metal/issues/$1"
+    },
+    "pullRequestConfig": {
+        "provider": "github",
+        "hostRootUrl": "https://github.com",
+        "sourceRemote": "origin",
+        "sourceOwner": "CastIronChat",
+        "sourceRepo": "twisted-metal",
+        "destRemote": "origin",
+        "destOwner": "CastIronChat",
+        "destRepo": "twisted-metal",
+        "destProjectId": "",
+        "destBranch": "main",
+        "custom": null
+    },
+    "exportedAt": 1668179202265
+}


### PR DESCRIPTION
I spent a few moments to configure this on my machine.  I figured it can only be helpful to others if I commit it to the project.  It will have no effect for people who do not use the "Git Graph" extension.

This file configures the "Git Graph" extension in two helpful ways:

The `"issueLinkingConfig"` means that `#1` syntax in commit messages, like in merges, will link to the github PR.
The `pullRequestConfig` enables a right-click option to create a pull request from the "Git Graph" UI.