### PR TITLE
Implement debugger timing and sequencing fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,17 @@
             "request": "launch",
             "program": "src/main.py",
             "console": "integratedTerminal",
+            "justMyCode": true,
+            "env": {
+                "USE_DEBUGGER_TIMING_FIXES": "true"
+            }
+        },
+        {
+            "name": "Run game, do *not* fix delta_time and update / draw ordering issues.",
+            "type": "python",
+            "request": "launch",
+            "program": "src/main.py",
+            "console": "integratedTerminal",
             "justMyCode": true
         }
     ]

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,16 @@
+import os
+
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
 SCREEN_TITLE = "John Deer Clown School"
 
 TICK_DURATION = 1 / 60
 "Duration of a single update tick of the game, measured in seconds"
+
+USE_DEBUGGER_TIMING_FIXES = os.environ.get("USE_DEBUGGER_TIMING_FIXES") == "true"
+"""
+Locks delta_time to exactly 1/60 of a second regardless of system clock,
+to make pausing in the debugger feasible.
+Also fixes known issue where, when pausing in debugger, update and draw each get
+called twice back-to-back instead of alternating once per.
+"""

--- a/src/main.py
+++ b/src/main.py
@@ -47,18 +47,10 @@ class MyGame(arcade.Window):
             self.all_sprites.append(sprite)
 
     def on_update(self, delta_time):
-        # In the debugger, we intentionally ignore the on_update() call we get from arcade engine.
-        # Instead, we call our own our_update() within on_draw()
-        # This avoids a known issue where debugger pauses can cause `on_update`` and `on_draw`` to happen in this order:
-        #   update
-        #   update
-        #   draw
-        #   draw
-        #   update
-        #   update
-        #   draw
-        #   draw
-        #   ...and so on.  Each is called twice, back-to-back.
+        # Arcade engine has a quirk where, in the debugger, it calls `on_update` twice back-to-back,
+        # then `on_draw` twice, and so on.
+        # We avoid this bug by ignoring the `on_update()` call from arcade, instead calling it ourselves
+        # from `on_draw`
         if not USE_DEBUGGER_TIMING_FIXES:
             self.our_update(delta_time)
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,13 @@ from typing import List
 
 import arcade
 
-from constants import SCREEN_HEIGHT, SCREEN_TITLE, SCREEN_WIDTH, TICK_DURATION
+from constants import (
+    SCREEN_HEIGHT,
+    SCREEN_TITLE,
+    SCREEN_WIDTH,
+    TICK_DURATION,
+    USE_DEBUGGER_TIMING_FIXES,
+)
 from input_debug_hud import InputDebugHud
 
 from player_manager import PlayerManager
@@ -40,15 +46,23 @@ class MyGame(arcade.Window):
         for sprite in self.hud.hud_sprite_list:
             self.all_sprites.append(sprite)
 
-    def on_draw(self):
-        # clear screen
-        self.clear()
-        self.all_sprites.draw()
-        for player in self.player_manager.players:
-            player.draw()
-        self.input_debug_hud.draw()
-
     def on_update(self, delta_time):
+        # In the debugger, we intentionally ignore the on_update() call we get from arcade engine.
+        # Instead, we call our own our_update() within on_draw()
+        # This avoids a known issue where debugger pauses can cause `on_update`` and `on_draw`` to happen in this order:
+        #   update
+        #   update
+        #   draw
+        #   draw
+        #   update
+        #   update
+        #   draw
+        #   draw
+        #   ...and so on.  Each is called twice, back-to-back.
+        if not USE_DEBUGGER_TIMING_FIXES:
+            self.our_update(delta_time)
+
+    def our_update(self, delta_time):
         # Pretty sure this does animation updates, in case any of the sprites
         # Have animations
 
@@ -56,6 +70,17 @@ class MyGame(arcade.Window):
             player.update(delta_time)
 
         self.hud.update()
+
+    def on_draw(self):
+        if USE_DEBUGGER_TIMING_FIXES:
+            self.our_update(TICK_DURATION)
+
+        # clear screen
+        self.clear()
+        self.all_sprites.draw()
+        for player in self.player_manager.players:
+            player.draw()
+        self.input_debug_hud.draw()
 
 
 def main():


### PR DESCRIPTION
Implements what we discussed in https://trello.com/c/SiDepwY2/55-handling-simulation-update-frequency

Adds a second debugger configuration.  The first, the default, will use the fixes implemented in this PR.

The second disables these fixes, to mimic the way the game will execute outside of the debugger.  It should not be necessary, but may be useful if you suspect these fixes are causing bugs and want to try running without them.