### PR TITLE
Experiment to avoid verbose repetition in subclass __init__

### DIFF
--- a/src/weapon.py
+++ b/src/weapon.py
@@ -27,6 +27,15 @@ class Weapon:
         self.weapon_sprite_offset = weapon_sprite_offset
         self.time_since_shoot = 100
         self.weapon_sprite = arcade.Sprite(texture=self.weapon_icon, scale=3)
+        self.setup()
+
+    def setup(self):
+        """
+        Override this method if you want to add initialization logic without
+        writing a verbose __init__
+        This method will be called by Weapon's __init__
+        """
+        ...
 
     def update(self):
         self.weapon_sprite.angle = self.car.angle
@@ -52,13 +61,7 @@ class LaserBeam(Weapon):
     # Is a class attribute, not instance attribute
     weapon_icon = LASER_PISTOL
 
-    def __init__(
-        self,
-        input_button: VirtualButton,
-        car: arcade.Sprite,
-        weapon_sprite_offset: Tuple[float, float],
-    ):
-        super().__init__(input_button, car, weapon_sprite_offset)
+    def setup(self):
         self.beam_range = 500
         self.beam_projection: SpriteForBeam = SpriteForBeam(self)
 
@@ -95,13 +98,7 @@ class Rocket(Weapon):
     fire_rate: float
     weapon_icon = ROCKET_LAUNCHER
 
-    def __init__(
-        self,
-        input_button: VirtualButton,
-        car: arcade.Sprite,
-        weapon_sprite_offset: Tuple[float, float],
-    ):
-        super().__init__(input_button, car, weapon_sprite_offset)
+    def setup(self):
         self.rocket_speed = 300
         self.fire_rate = 0.5
 
@@ -136,13 +133,7 @@ class MachineGun(Weapon):
     fire_rate: float
     weapon_icon = MACHINE_GUN
 
-    def __init__(
-        self,
-        input_button: VirtualButton,
-        car: arcade.Sprite,
-        weapon_sprite_offset: Tuple[float, float],
-    ):
-        super().__init__(input_button, car, weapon_sprite_offset)
+    def setup(self):
         self.bullet_speed = 500
         self.fire_rate = 10
 


### PR DESCRIPTION
Marking this PR as "draft" because I don't know if we want to merge it, I'm proposing it as a general pattern we might use going forward.

We were talking on Discord about the repetition of `__init__` parameters in each subclass of `Weapon`

This PR avoids the need for subclass `__init__`s by moving their logic into a `setup()` method.  This method is automatically called by `Weapon`'s `__init__`.  Subclasses are free to override the `setup()` method and put their initialization logic there.  `setup()` does not need to accept any parameters.