### PR TITLE
Add alternate mario-kart style(?) controller binding

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -15,7 +15,7 @@ Also fixes known issue where, when pausing in debugger, update and draw each get
 called twice back-to-back instead of alternating once per.
 """
 
-USE_ALTERNATE_CONTROLLER_LAYOUT = False
+START_WITH_ALTERNATE_CONTROLLER_LAYOUT = False
 """
 Use alternate (Mario Kart-style?) controller layout where A/B are gas and brake,
 and triggers are primary/secondary fire.  At this early stage of development,

--- a/src/constants.py
+++ b/src/constants.py
@@ -14,3 +14,10 @@ to make pausing in the debugger feasible.
 Also fixes known issue where, when pausing in debugger, update and draw each get
 called twice back-to-back instead of alternating once per.
 """
+
+USE_ALTERNATE_CONTROLLER_LAYOUT = False
+"""
+Use alternate (Mario Kart-style?) controller layout where A/B are gas and brake,
+and triggers are primary/secondary fire.  At this early stage of development,
+this flag is meant for experimentation.
+"""

--- a/src/input_debug_hud.py
+++ b/src/input_debug_hud.py
@@ -43,7 +43,7 @@ class InputDebugHud:
     def get_readout(self):
         lines = []
         for (index, player_input) in enumerate(self.player_inputs):
-            lines += [f"Player #{index + 1}"]
+            lines += [f"Player #{index + 1}: {player_input.layout_name} layout"]
             lines += [
                 f"{control}: {getattr(player_input, control).value}"
                 for control in self.controls

--- a/src/player_input.py
+++ b/src/player_input.py
@@ -151,6 +151,14 @@ def set_default_controller_layout(player_input: PlayerInput):
     player_input.reload_button.button = "x"
 
 
+def set_alternate_controller_layout(player_input: PlayerInput):
+    set_default_controller_layout(player_input)
+    player_input.accelerate_axis.button_positive = "a"
+    player_input.brake_axis.button_positive = "b"
+    player_input.primary_fire_button.button = "righttrigger"
+    player_input.secondary_fire_button.button = "lefttrigger"
+
+
 def bind_to_keyboard(player_input: PlayerInput):
     player_input.x_axis.key_negative = arcade.key.A
     player_input.x_axis.key_positive = arcade.key.D

--- a/src/player_manager.py
+++ b/src/player_manager.py
@@ -2,9 +2,15 @@ from typing import List
 
 from pyglet.input import ControllerManager
 from pyglet.window.key import KeyStateHandler
+from constants import USE_ALTERNATE_CONTROLLER_LAYOUT
 
 from player import Player
-from player_input import PlayerInput, bind_to_keyboard, set_default_controller_layout
+from player_input import (
+    PlayerInput,
+    bind_to_keyboard,
+    set_alternate_controller_layout,
+    set_default_controller_layout,
+)
 
 PLAYER_COUNT = 4
 KEYBOARD_PLAYER_INDEX = 0
@@ -61,7 +67,10 @@ class PlayerManager:
             player_input = PlayerInput(self._keyboard, controller)
             if player_index == KEYBOARD_PLAYER_INDEX:
                 bind_to_keyboard(player_input)
-            set_default_controller_layout(player_input)
+            if USE_ALTERNATE_CONTROLLER_LAYOUT:
+                set_alternate_controller_layout(player_input)
+            else:
+                set_default_controller_layout(player_input)
             player = Player(player_input)
 
             self.players.append(player)

--- a/src/player_manager.py
+++ b/src/player_manager.py
@@ -2,14 +2,13 @@ from typing import List
 
 from pyglet.input import ControllerManager
 from pyglet.window.key import KeyStateHandler
-from constants import USE_ALTERNATE_CONTROLLER_LAYOUT
+from constants import START_WITH_ALTERNATE_CONTROLLER_LAYOUT
 
 from player import Player
 from player_input import (
     PlayerInput,
     bind_to_keyboard,
-    set_alternate_controller_layout,
-    set_default_controller_layout,
+    set_controller_layout,
 )
 
 PLAYER_COUNT = 4
@@ -67,10 +66,7 @@ class PlayerManager:
             player_input = PlayerInput(self._keyboard, controller)
             if player_index == KEYBOARD_PLAYER_INDEX:
                 bind_to_keyboard(player_input)
-            if USE_ALTERNATE_CONTROLLER_LAYOUT:
-                set_alternate_controller_layout(player_input)
-            else:
-                set_default_controller_layout(player_input)
+            set_controller_layout(player_input, START_WITH_ALTERNATE_CONTROLLER_LAYOUT)
             player = Player(player_input)
 
             self.players.append(player)
@@ -82,3 +78,10 @@ class PlayerManager:
         """
         for player in self.players:
             player.input.update()
+            if player.input.debug_2.pressed or player.input.debug_2.released:
+                # xor
+                alternate = (
+                    player.input.debug_2.toggle
+                    != START_WITH_ALTERNATE_CONTROLLER_LAYOUT
+                )
+                set_controller_layout(player.input, alternate)


### PR DESCRIPTION
Only differences in the alternate layout: A/B and triggers are swapped.  Triggers do shooting, A/B do gas and brake.

I bound it to a `constants.py` flag.  I suppose it could also be bound to one of the new `debug_*` inputs from #36 if we wanted to toggle during gameplay.