### PR TITLE
Add spawn points

### DIFF
--- a/assets/arenas/arenas.tiled-project
+++ b/assets/arenas/arenas.tiled-project
@@ -24,6 +24,29 @@
                 "wangcolor",
                 "wangset"
             ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "id": 2,
+            "members": [
+                {
+                    "name": "initial_spawn_for_player",
+                    "type": "string",
+                    "value": ""
+                }
+            ],
+            "name": "SpawnPoint",
+            "type": "class",
+            "useAs": [
+                "property",
+                "map",
+                "layer",
+                "object",
+                "tile",
+                "tileset",
+                "wangcolor",
+                "wangset"
+            ]
         }
     ]
 }

--- a/assets/arenas/default.tmx
+++ b/assets/arenas/default.tmx
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="19" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="12">
- <layer id="1" name="tiles" width="25" height="19">
-  <data encoding="csv">
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-</data>
- </layer>
+<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="19" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="25">
+ <tileset firstgid="1" source="tiled_objects.tsx"/>
  <objectgroup id="2" name="objects">
   <object id="1" name="top" class="Wall" x="0" y="0" width="800" height="32"/>
   <object id="2" name="left" class="Wall" x="0" y="0" width="32" height="600"/>
   <object id="3" name="obstacle" class="Wall" x="284.628" y="227.89" width="267.863" height="37.4674" rotation="20"/>
   <object id="4" name="bottom" class="Wall" x="0" y="576" width="800" height="32"/>
   <object id="7" name="right" class="Wall" x="768" y="0" width="32" height="600"/>
+  <object id="17" class="SpawnPoint" gid="1" x="112.833" y="142.167" width="50" height="30">
+   <properties>
+    <property name="initial_spawn_for_player" value="3"/>
+   </properties>
+  </object>
+  <object id="18" class="SpawnPoint" gid="1" x="374.5" y="144.333" width="50" height="30"/>
+  <object id="19" class="SpawnPoint" gid="1" x="604" y="156.333" width="50" height="30">
+   <properties>
+    <property name="initial_spawn_for_player" value="2"/>
+   </properties>
+  </object>
+  <object id="20" class="SpawnPoint" gid="1" x="663" y="438.833" width="50" height="30" rotation="180">
+   <properties>
+    <property name="initial_spawn_for_player" value="1"/>
+   </properties>
+  </object>
+  <object id="21" class="SpawnPoint" gid="1" x="113.5" y="468.5" width="50" height="30">
+   <properties>
+    <property name="initial_spawn_for_player" value="0"/>
+   </properties>
+  </object>
+  <object id="22" template="tiled_templates/spawn_point.tx" class="SpawnPoint" x="417" y="441.833" rotation="180"/>
  </objectgroup>
 </map>

--- a/assets/arenas/tiled_objects.tsx
+++ b/assets/arenas/tiled_objects.tsx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.9" tiledversion="1.9.2" name="car" tilewidth="250" tileheight="124" tilecount="1" columns="0">
+ <grid orientation="orthogonal" width="1" height="1"/>
+ <tile id="0">
+  <image width="250" height="124" source="../vehicle/red-car-top-view.png"/>
+ </tile>
+</tileset>

--- a/assets/arenas/tiled_templates/spawn_point.tx
+++ b/assets/arenas/tiled_templates/spawn_point.tx
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template>
+ <tileset firstgid="1" source="../tiled_objects.tsx"/>
+ <object class="SpawnPoint" gid="1" width="50" height="30"/>
+</template>

--- a/src/arena/arena.py
+++ b/src/arena/arena.py
@@ -2,6 +2,7 @@ from typing import List, cast
 from collections.abc import Sequence
 
 from arcade import SpriteList
+from arena.spawn_point import SpawnPoint
 
 from arena.wall import Wall
 
@@ -10,6 +11,8 @@ class Arena:
     def __init__(self) -> None:
         self._walls: List[Wall] = []
         self._sprite_list: SpriteList
+        self._spawn_points: List[SpawnPoint] = []
+        self._initial_spawn_points: List[SpawnPoint] = [None, None, None, None]
 
     @property
     def walls(self) -> Sequence[Wall]:
@@ -18,6 +21,14 @@ class Arena:
     @property
     def wall_sprite_list(self) -> SpriteList:
         return self._sprite_list
+
+    @property
+    def spawn_points(self) -> Sequence[SpawnPoint]:
+        return self._spawn_points
+
+    @property
+    def initial_spawn_points(self) -> Sequence[SpawnPoint]:
+        return self._initial_spawn_points
 
     def init_for_drawing(self):
         """

--- a/src/arena/arena_loader.py
+++ b/src/arena/arena_loader.py
@@ -2,8 +2,9 @@ import math
 import arcade
 from arena.arena import Arena
 from pytiled_parser import ObjectLayer
-from pytiled_parser.tiled_object import Rectangle
+from pytiled_parser.tiled_object import Rectangle, TiledObject
 from math import radians
+from arena.spawn_point import SpawnPoint
 
 from arena.wall import Wall
 from constants import SCREEN_HEIGHT
@@ -28,21 +29,71 @@ def load_arena_by_name(name: str) -> Arena:
                 raise Exception(
                     "Found a Tiled object with the 'Wall' class that is not a Rectangle. Only rectangles may be used for walls."
                 )
-            converted_position = (
-                object.coordinates.x,
-                y_offset - object.coordinates.y,
-            )
-            rotation = radians(-object.rotation)
-            center_offset = scale_vec((object.size.width, -object.size.height), 0.5)
-            rotated_center_offset = rotate_vec(center_offset, rotation)
-            center = add_vec(rotated_center_offset, converted_position)
+            transform, size = get_rectangle_object_transform_and_size(object)
 
-            wall = Wall(
-                int(center[0]),
-                int(center[1]),
-                int(object.size.width),
-                int(object.size.height),
-                rotation,
-            )
+            wall = Wall(transform, size)
             arena._walls.append(wall)
+        elif object.class_ == "SpawnPoint":
+            transform, size = get_tile_object_transform_and_size(object)
+            initial_spawn_for_player_str = object.properties.get(
+                "initial_spawn_for_player"
+            )
+            initial_spawn_for_player = None
+            if initial_spawn_for_player_str is not None:
+                initial_spawn_for_player = int(initial_spawn_for_player_str)
+
+            spawn_point = SpawnPoint(transform, initial_spawn_for_player)
+
+            arena._spawn_points.append(spawn_point)
+            if initial_spawn_for_player is not None:
+                arena._initial_spawn_points[initial_spawn_for_player] = spawn_point
+
     return arena
+
+
+def get_tile_object_transform_and_size(object: TiledObject):
+    """
+    Return the transform and dimensions of a Tile Object loaded from Tiled map editor.
+
+    Returns (transform, size) where:
+
+    transform = (x, y, radians)
+
+    size = (width, height)
+    """
+    return get_object_transform_and_size(object, True)
+
+
+def get_rectangle_object_transform_and_size(object: TiledObject):
+    """
+    Return the transform and dimensions of a Rectangle Object loaded from Tiled map editor.
+
+    Returns (transform, size) where:
+
+    transform = (x, y, radians)
+
+    size = (width, height)
+    """
+    return get_object_transform_and_size(object, False)
+
+
+def get_object_transform_and_size(object: TiledObject, pivot_is_at_bottom: bool):
+    y_offset = SCREEN_HEIGHT
+    converted_position = (
+        object.coordinates.x,
+        y_offset - object.coordinates.y,
+    )
+    rotation = radians(-object.rotation)
+
+    # TODO I kinda hate this syntax; why is python like this?
+    height_offset = object.size.height if pivot_is_at_bottom else -object.size.height
+
+    center_offset = scale_vec((object.size.width, height_offset), 0.5)
+    rotated_center_offset = rotate_vec(center_offset, rotation)
+    center = add_vec(rotated_center_offset, converted_position)
+
+    transform = (center[0], center[1], rotation)
+
+    size = (object.size.width, object.size.height)
+
+    return (transform, size)

--- a/src/arena/spawn_point.py
+++ b/src/arena/spawn_point.py
@@ -1,0 +1,12 @@
+from typing import Optional, Tuple
+
+
+class SpawnPoint:
+    def __init__(
+        self,
+        transform: Tuple[float, float, float],
+        initial_spawn_for_player: Optional[int],
+    ):
+        self.initial_spawn_for_player = initial_spawn_for_player
+        "If an int, is the zero-indexed initial spawn point for a player.  0 == initial spawn point for player 1.  Defaults to None"
+        self.transform = transform

--- a/src/arena/wall.py
+++ b/src/arena/wall.py
@@ -1,15 +1,17 @@
-from arcade import Sprite, SpriteSolidColor, color
-import arcade
+from typing import Tuple
+from arcade import color
+from iron_math import move_sprite
+
+from linked_sprite import LinkedSprite, LinkedSpriteSolidColor
 
 
 class Wall:
-    def __init__(self, x: int, y: int, width: int, height: int, angle=0.0) -> None:
-        self._x = x
-        self._y = y
-        self._width = width
-        self._height = height
-        self._angle = angle
-        self._sprite: SpriteForWall
+    def __init__(
+        self, transform: Tuple[float, float, float], size: Tuple[float, float]
+    ) -> None:
+        self._transform = transform
+        self._size = size
+        self._sprite: LinkedSprite[Wall]
         self.init_for_drawing()
 
     @property
@@ -22,12 +24,9 @@ class Wall:
         representation
         """
 
-        self._sprite = SpriteForWall(self._width, self._height, color.BLACK)
-        self._sprite.wall = self
+        self._sprite = LinkedSpriteSolidColor[Wall](
+            int(self._size[0]), int(self._size[1]), color.BLACK
+        )
+        self._sprite.owner = self
 
-        self._sprite.set_position(self._x, self._y)
-        self._sprite.radians = self._angle
-
-
-class SpriteForWall(SpriteSolidColor):
-    wall: Wall
+        move_sprite(self._sprite, self._transform)

--- a/src/bullet.py
+++ b/src/bullet.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import arcade
 import math
+from arena.wall import Wall
 from constants import SCREEN_HEIGHT, SCREEN_WIDTH
 from iron_math import add_vec, rotate_vec, move_sprite_relative_to_parent
 
 from typing import List, cast
-from arena.wall import SpriteForWall
 from linked_sprite import LinkedSprite
 
 # This allows a circular import only for the purposes of type hints
@@ -47,7 +47,7 @@ def bullet_behavior(
     for projectile_sprite in projectile_sprite_list:
         projectile_sprite: LinkedSprite[Projectile]
         wall_sprites_collided_with_bullet = cast(
-            List[SpriteForWall],
+            List[LinkedSprite[Wall]],
             arcade.check_for_collision_with_list(projectile_sprite, list_of_walls),
         )
         if len(wall_sprites_collided_with_bullet) > 0:

--- a/src/iron_math.py
+++ b/src/iron_math.py
@@ -61,6 +61,20 @@ def move_sprite_relative_to_parent(
     child.position = add_vec(parent.position, rotate_vec(transform[:2], parent.radians))
 
 
+def move_sprite(
+    sprite: arcade.Sprite,
+    transform: Tuple[float, float, float],
+    /,
+):
+    """
+    Move sprite to a new position and rotation.
+
+    transform = (x, y, radians)
+    """
+    sprite.radians = transform[2]
+    sprite.position = transform[:2]
+
+
 def get_transformed_location(
     parent: arcade.Sprite, transform: Tuple[float, float, float], /
 ):

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ import arcade
 
 from arena.arena import Arena
 from arena.arena_loader import load_arena_by_name
-from arena.wall import SpriteForWall
 from bullet import bullet_behavior
 from constants import (
     SCREEN_HEIGHT,
@@ -37,9 +36,17 @@ class MyGame(arcade.Window):
         self.projectile_sprite_list = arcade.SpriteList()
         self.beam_sprite_list = arcade.SpriteList()
         self.player_sprite_list = arcade.SpriteList()
+
+        # Arena
+        self.arena = load_arena_by_name("default")
+        self.arena.init_for_drawing()
+
         # Players
         self.player_manager.setup(
-            self.projectile_sprite_list, self.beam_sprite_list, self.player_sprite_list
+            self.projectile_sprite_list,
+            self.beam_sprite_list,
+            self.player_sprite_list,
+            self.arena,
         )
 
         # Debug UI for input handling
@@ -51,9 +58,6 @@ class MyGame(arcade.Window):
         self.hud = Hud(self.player_manager.players)
         for sprite in self.hud.hud_sprite_list:
             self.all_sprites.append(sprite)
-
-        self.arena = load_arena_by_name("default")
-        self.arena.init_for_drawing()
 
     def on_update(self, delta_time):
         # Arcade engine has a quirk where, in the debugger, it calls `on_update` twice back-to-back,

--- a/src/player_manager.py
+++ b/src/player_manager.py
@@ -3,7 +3,9 @@ import arcade
 
 from pyglet.input import ControllerManager
 from pyglet.window.key import KeyStateHandler
+from arena.arena import Arena
 from constants import START_WITH_ALTERNATE_CONTROLLER_LAYOUT
+from iron_math import move_sprite
 
 from player import Player
 from player_input import (
@@ -50,6 +52,7 @@ class PlayerManager:
         projectile_sprite_list: arcade.SpriteList,
         beam_sprite_list: arcade.SpriteList,
         player_sprite_list: arcade.SpriteList,
+        arena: Arena,
     ):
         if self._did_setup:
             raise Exception("Already setup; cannot setup twice")
@@ -74,6 +77,8 @@ class PlayerManager:
                 bind_to_keyboard(player_input)
             set_controller_layout(player_input, START_WITH_ALTERNATE_CONTROLLER_LAYOUT)
             player = Player(player_input, projectile_sprite_list, beam_sprite_list)
+            spawn_point = arena.initial_spawn_points[player_index]
+            move_sprite(player.sprite, spawn_point.transform)
             player_sprite_list.append(player.sprite)
             self.players.append(player)
 


### PR DESCRIPTION
Add list of `SpawnPoint`s to `Arena`

Add spawn points to default arena

Parse spawn points from Tiled `.tmx` files in arena loading logic

Use initial spawn points to position players in `PlayerManager`
- Players 1 and 2 spawn facing each other

Add new tileset in Tiled, helpful for representing map entities graphically within the Tiled editor

Add new "template" for spawn points in Tiled, helpful to drag-and-drop a spawn point from the sidebar into the map