### PR TITLE
Improved the projectile setup method

### DIFF
--- a/src/projectile.py
+++ b/src/projectile.py
@@ -22,9 +22,10 @@ class Projectile:
 
     sprite: LinkedSprite[Projectile]
     sprite_lists: SpriteLists
+    muzzle_location: Tuple[float, float, float]
     damage: float
     speed: float
-    radians: float
+    angle_of_motion: float
     sprite_rotation_offset: float
     exists: bool
     """
@@ -37,26 +38,29 @@ class Projectile:
         self,
         sprite: LinkedSprite[Projectile],
         sprite_lists: SpriteLists,
-        speed: float,
-        radians: float,
         damage: float,
     ):
         self.sprite = sprite
         sprite.owner = self
         self.sprite_lists = sprite_lists
-        self.speed = speed
-        self.radians = radians
         self.damage = damage
-        self.explodes = False
         self.exists = False
-        self.sprite_rotation_offset = 0
-        self.setup()
+        self.speed = 0
+        self.angle_of_motion = 0
 
-    def setup(self):
+    def setup(self, muzzle_location : Tuple[float, float, float], speed: float,
+        angle_of_motion: float, sprite_rotation_offet:float = 0, explodes: bool = False):
+        self.muzzle_location = muzzle_location
+        self.speed = speed
+        self.angle_of_motion = angle_of_motion
+        self.sprite_rotation_offset = sprite_rotation_offet
+        self.explodes = explodes
+        set_sprite_location(self.sprite, muzzle_location)
+        self.sprite.radians += self.sprite_rotation_offset
         self.append_sprite()
 
     def update(self, delta_time: float):
-        move_sprite_polar(self.sprite, self.speed * delta_time, self.radians)
+        move_sprite_polar(self.sprite, self.speed * delta_time, self.angle_of_motion)
         # check if the projectile left the screen
         if not sprite_in_bounds(self.sprite):
             self.remove_sprite()
@@ -68,11 +72,6 @@ class Projectile:
             self.sprite.center_y,
             self.sprite.radians - self.sprite_rotation_offset,
         )
-
-    @location.setter
-    def location(self, location: Tuple[float, float, float]):
-        set_sprite_location(self.sprite, location)
-        self.sprite.radians += self.sprite_rotation_offset
 
     def append_sprite(self):
         self.sprite_lists.projectiles.append(self.sprite)
@@ -98,11 +97,13 @@ class Beam(Projectile):
 
     beam_range: float
 
-    def setup(self):
-        self.beam_range = self.sprite.width
+    def setup(self, beam_range:float, explodes: bool = False):
+        self.beam_range = beam_range
+        self.explodes = explodes
 
     def update(self, delta_time: float):
-        pass
+        set_sprite_location(self.sprite, self.muzzle_location)
+        move_sprite_polar(self.sprite, self.sprite.width/2, self.muzzle_location[2])
 
     def on_collision_with_wall(self, walls_touching_projectile: arcade.SpriteList):
         pass

--- a/src/projectile.py
+++ b/src/projectile.py
@@ -48,8 +48,14 @@ class Projectile:
         self.speed = 0
         self.angle_of_motion = 0
 
-    def setup(self, muzzle_location : Tuple[float, float, float], speed: float,
-        angle_of_motion: float, sprite_rotation_offet:float = 0, explodes: bool = False):
+    def setup(
+        self,
+        muzzle_location: Tuple[float, float, float],
+        speed: float,
+        angle_of_motion: float,
+        sprite_rotation_offet: float = 0,
+        explodes: bool = False,
+    ):
         self.muzzle_location = muzzle_location
         self.speed = speed
         self.angle_of_motion = angle_of_motion
@@ -97,13 +103,13 @@ class Beam(Projectile):
 
     beam_range: float
 
-    def setup(self, beam_range:float, explodes: bool = False):
+    def setup(self, beam_range: float, explodes: bool = False):
         self.beam_range = beam_range
         self.explodes = explodes
 
     def update(self, delta_time: float):
         set_sprite_location(self.sprite, self.muzzle_location)
-        move_sprite_polar(self.sprite, self.sprite.width/2, self.muzzle_location[2])
+        move_sprite_polar(self.sprite, self.sprite.width / 2, self.muzzle_location[2])
 
     def on_collision_with_wall(self, walls_touching_projectile: arcade.SpriteList):
         pass

--- a/src/weapon.py
+++ b/src/weapon.py
@@ -78,7 +78,7 @@ class LaserBeam(Weapon):
     def setup(self):
         self.beam_range = 400
         self.dps = 20
-        self.muzzle_transform = (20 + self.beam_range / 2, 5, 0)
+        self.muzzle_transform = (20, 5, 0)
         self.create_beam()
 
     def update(self, delta_time: float):
@@ -103,11 +103,14 @@ class LaserBeam(Weapon):
         beam_appearance = LinkedSpriteSolidColor[Projectile](
             self.beam_range, 5, arcade.color.RED
         )
-        self.beam = Beam(beam_appearance, self.sprite_lists, 0, 0, self.dps)
+        self.beam = Beam(beam_appearance, self.sprite_lists, self.dps)
+        self.beam.setup(self.beam_range)
 
     def aim_beam(self):
         if self.beam.exists:
-            self.beam.location = get_transformed_location(self.weapon_sprite, self.muzzle_transform)
+            self.beam.muzzle_location = get_transformed_location(
+                self.weapon_sprite, self.muzzle_transform
+            )
 
 
 class RocketLauncher(Weapon):
@@ -138,14 +141,16 @@ class RocketLauncher(Weapon):
         rocket = Projectile(
             rocket_appearance,
             self.sprite_lists,
-            self.rocket_speed,
-            self.weapon_sprite.radians,
             self.rocket_damage,
         )
         # ROCKET texture appears at 45 degree angle. Sprite_rotation_offset compensates for this
-        rocket.sprite_rotation_offset = (math.radians(-45))
-        rocket.location = get_transformed_location(self.weapon_sprite, self.muzzle_transform)
-        rocket.explodes = True
+        rocket.setup(
+            get_transformed_location(self.weapon_sprite, self.muzzle_transform),
+            self.rocket_speed,
+            self.weapon_sprite.radians,
+            sprite_rotation_offet=math.radians(-45),
+            explodes=True,
+        )
         self.time_since_shoot = 0
 
 
@@ -176,9 +181,11 @@ class MachineGun(Weapon):
         bullet = Projectile(
             bullet_appearance,
             self.sprite_lists,
-            self.bullet_speed,
-            self.weapon_sprite.radians,
             self.bullet_damage,
         )
-        bullet.location = get_transformed_location(self.weapon_sprite, self.muzzle_transform)
+        bullet.setup(
+            get_transformed_location(self.weapon_sprite, self.muzzle_transform),
+            self.bullet_speed,
+            self.weapon_sprite.radians,
+        )
         self.time_since_shoot = 0


### PR DESCRIPTION
Minor fixes to the projectile class to make things cleaner.

Weapons now call a setup method after initializing a projectile that replaces several other commands that were being called. Setup is different for normal projectiles and beams

Also beams are still controlled by the weapon, but they now update when the rest of the projectiles are updated