### PR TITLE
Debug-mode player 2 autopilot, so you can shoot a moving target

### DIFF
--- a/assets/arenas/arenas.tiled-project
+++ b/assets/arenas/arenas.tiled-project
@@ -9,20 +9,20 @@
     "propertyTypes": [
         {
             "color": "#ffa0a0a4",
-            "id": 1,
+            "id": 4,
             "members": [
+                {
+                    "name": "next",
+                    "type": "object",
+                    "value": 0
+                }
             ],
-            "name": "Wall",
+            "name": "PatrolWaypoint",
             "type": "class",
             "useAs": [
                 "property",
-                "map",
-                "layer",
                 "object",
-                "tile",
-                "tileset",
-                "wangcolor",
-                "wangset"
+                "tile"
             ]
         },
         {
@@ -39,13 +39,21 @@
             "type": "class",
             "useAs": [
                 "property",
-                "map",
-                "layer",
                 "object",
-                "tile",
-                "tileset",
-                "wangcolor",
-                "wangset"
+                "tile"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "id": 1,
+            "members": [
+            ],
+            "name": "Wall",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object",
+                "tile"
             ]
         }
     ]

--- a/assets/arenas/default.tmx
+++ b/assets/arenas/default.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="19" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="25">
+<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="19" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="31">
  <tileset firstgid="1" source="tiled_objects.tsx"/>
  <objectgroup id="2" name="objects">
   <object id="1" name="top" class="Wall" x="0" y="0" width="800" height="32"/>
@@ -29,5 +29,41 @@
    </properties>
   </object>
   <object id="22" template="tiled_templates/spawn_point.tx" class="SpawnPoint" x="417" y="441.833" rotation="180"/>
+  <object id="25" class="PatrolWaypoint" x="668.667" y="322">
+   <properties>
+    <property name="next" type="object" value="26"/>
+   </properties>
+   <point/>
+  </object>
+  <object id="26" class="PatrolWaypoint" x="542.667" y="200">
+   <properties>
+    <property name="next" type="object" value="27"/>
+   </properties>
+   <point/>
+  </object>
+  <object id="27" class="PatrolWaypoint" x="220.667" y="142">
+   <properties>
+    <property name="next" type="object" value="28"/>
+   </properties>
+   <point/>
+  </object>
+  <object id="28" class="PatrolWaypoint" x="170.667" y="330">
+   <properties>
+    <property name="next" type="object" value="29"/>
+   </properties>
+   <point/>
+  </object>
+  <object id="29" class="PatrolWaypoint" x="365.333" y="393.333">
+   <properties>
+    <property name="next" type="object" value="30"/>
+   </properties>
+   <point/>
+  </object>
+  <object id="30" class="PatrolWaypoint" x="486.667" y="513.333">
+   <properties>
+    <property name="next" type="object" value="25"/>
+   </properties>
+   <point/>
+  </object>
  </objectgroup>
 </map>

--- a/src/arena/arena.py
+++ b/src/arena/arena.py
@@ -5,9 +5,9 @@ from typing import List, cast
 
 from arcade import SpriteList
 
-from path import Path
 from arena.spawn_point import SpawnPoint
 from arena.wall import Wall
+from path import Path
 from sprite_lists import SpriteLists
 
 
@@ -16,7 +16,7 @@ class Arena:
         self._walls: List[Wall] = []
         self._spawn_points: List[SpawnPoint] = []
         self._initial_spawn_points: List[SpawnPoint] = [None, None, None, None]
-        self._patrol_loop: Path
+        self.patrol_loop: Path
 
     @property
     def walls(self) -> Sequence[Wall]:

--- a/src/arena/arena.py
+++ b/src/arena/arena.py
@@ -5,6 +5,7 @@ from typing import List, cast
 
 from arcade import SpriteList
 
+from path import Path
 from arena.spawn_point import SpawnPoint
 from arena.wall import Wall
 from sprite_lists import SpriteLists
@@ -15,6 +16,7 @@ class Arena:
         self._walls: List[Wall] = []
         self._spawn_points: List[SpawnPoint] = []
         self._initial_spawn_points: List[SpawnPoint] = [None, None, None, None]
+        self._patrol_loop: Path
 
     @property
     def walls(self) -> Sequence[Wall]:

--- a/src/arena/arena_loader.py
+++ b/src/arena/arena_loader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from math import radians
 
 import arcade
@@ -8,10 +7,12 @@ from pytiled_parser import ObjectLayer
 from pytiled_parser.tiled_object import Rectangle, TiledObject
 
 from arena.arena import Arena
+from arena.patrol_waypoint import PatrolWaypoint
 from arena.spawn_point import SpawnPoint
 from arena.wall import Wall
 from constants import SCREEN_HEIGHT
 from iron_math import add_vec, rotate_vec, scale_vec
+from path import Path
 
 
 def load_arena_by_name(name: str) -> Arena:
@@ -25,8 +26,11 @@ def load_arena_by_name(name: str) -> Arena:
     object_layer = next(
         layer for layer in tilemap.tiled_map.layers if isinstance(layer, ObjectLayer)
     )
-    # Create walls from all rectangles with the "Wall" class set in Tiled
+    objects_by_id = dict()
+    patrol_waypoints: dict[PatrolWaypoint] = dict()
+    # tiled_object_to_waypoint_map
     for object in object_layer.tiled_objects:
+        objects_by_id[object.id] = object
         if object.class_ == "Wall":
             if not isinstance(object, Rectangle):
                 raise Exception(
@@ -50,6 +54,37 @@ def load_arena_by_name(name: str) -> Arena:
             arena._spawn_points.append(spawn_point)
             if initial_spawn_for_player is not None:
                 arena._initial_spawn_points[initial_spawn_for_player] = spawn_point
+        elif object.class_ == "PatrolWaypoint":
+            transform, size = get_tile_object_transform_and_size(object)
+            patrol_waypoints[object.id] = PatrolWaypoint(transform[:2])
+
+    # Discover patrol loops
+    patrol_loops: list[list[PatrolWaypoint]] = []
+    while len(patrol_waypoints):
+        patrol_loop: list[PatrolWaypoint] = []
+        patrol_loops.append(patrol_loop)
+        object_id, waypoint = patrol_waypoints.popitem()
+        first_object_id = object_id
+        object = objects_by_id[object_id]
+        patrol_loop.append(waypoint)
+        while True:
+            object_id = int(object.properties["next"])
+            object = objects_by_id[object_id]
+            # If we completed the loop, stop here
+            if object_id == first_object_id:
+                break
+            waypoint = patrol_waypoints.pop(object_id)
+            patrol_loop.append(waypoint)
+    if len(patrol_loops) != 1:
+        raise Exception(
+            "Arena must have exactly one patrol loop.  This restriction will likely be removed in the future."
+        )
+    arena._patrol_loop = Path(
+        [
+            (index * 1.0, point.location[0], point.location[1])
+            for index, point in enumerate(patrol_loops[0] + [patrol_loops[0][0]])
+        ]
+    )
 
     return arena
 

--- a/src/arena/arena_loader.py
+++ b/src/arena/arena_loader.py
@@ -79,7 +79,7 @@ def load_arena_by_name(name: str) -> Arena:
         raise Exception(
             "Arena must have exactly one patrol loop.  This restriction will likely be removed in the future."
         )
-    arena._patrol_loop = Path(
+    arena.patrol_loop = Path(
         [
             (index * 1.0, point.location[0], point.location[1])
             for index, point in enumerate(patrol_loops[0] + [patrol_loops[0][0]])

--- a/src/arena/patrol_waypoint.py
+++ b/src/arena/patrol_waypoint.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+class PatrolWaypoint:
+    def __init__(self, location: tuple[float, float]):
+        self.location = location

--- a/src/constants.py
+++ b/src/constants.py
@@ -34,7 +34,7 @@ Useful if you want to debug two players and you only have one controller.
 
 PLAYER_ON_PATROL_LOOP = None
 """
-If set to a player index, 0 to 3, then that player will be moved on autopilot in
+If set to a player number, 1 to 4, then that player will be moved on autopilot in
 a loop around the map, giving you a moving target to shoot at while testing.
 """
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -46,3 +46,8 @@ START_FULLSCREEN = False
 """
 Start the game in fullscreen mode.  Can also be toggled with F11 on keyboard.
 """
+
+ARENA = "default"
+"""
+Loads this arena at startup, from assets/arenas/<ARENA>.tmx
+"""

--- a/src/constants.py
+++ b/src/constants.py
@@ -32,6 +32,12 @@ If false, keyboard player will be controlled by keyboard, *not* a controller.
 Useful if you want to debug two players and you only have one controller.
 """
 
+PLAYER_ON_PATROL_LOOP = None
+"""
+If set to a player index, 0 to 3, then that player will be moved on autopilot in
+a loop around the map, giving you a moving target to shoot at while testing.
+"""
+
 DRAW_DRIVE_MODE_DEBUG_HUD = True
 """
 Draw a text overlay with the name of each player's current driving mode.

--- a/src/debug_patrol_loop.py
+++ b/src/debug_patrol_loop.py
@@ -12,18 +12,24 @@ class DebugPatrolLoop:
     def __init__(self, player_manager: PlayerManager, arena: Arena):
         self.player_manager = player_manager
         self.arena = arena
-        self.patrol_timer = 0.0
+        self.patrol_timer = self.arena.patrol_loop.min_time
 
     def update(self, delta_time: float):
         # skip if not enabled
         if PLAYER_ON_PATROL_LOOP is None:
             return
+        max_time = self.arena.patrol_loop.max_time
         self.patrol_timer += delta_time
-        if self.patrol_timer >= self.arena._patrol_loop.max_time:
-            self.patrol_timer = self.arena._patrol_loop.min_time
-        player = self.player_manager.players[PLAYER_ON_PATROL_LOOP]
-        position = self.arena._patrol_loop.sample(self.patrol_timer)
-        position_soon = self.arena._patrol_loop.sample(self.patrol_timer + 0.2)
+        if self.patrol_timer >= max_time:
+            self.patrol_timer = self.arena.patrol_loop.min_time
+        patrol_timer_soon = self.patrol_timer + 0.2
+        if patrol_timer_soon >= max_time:
+            patrol_timer_soon = (
+                self.arena.patrol_loop.min_time + patrol_timer_soon - max_time
+            )
+        player = self.player_manager.players[PLAYER_ON_PATROL_LOOP - 1]
+        position = self.arena.patrol_loop.sample(self.patrol_timer)
+        position_soon = self.arena.patrol_loop.sample(patrol_timer_soon)
         heading_vec = subtract_vec(position_soon, position)
         heading_radians = math.atan2(heading_vec[1], heading_vec[0])
         player.location = (position[0], position[1], heading_radians)

--- a/src/debug_patrol_loop.py
+++ b/src/debug_patrol_loop.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import math
+
+from arena.arena import Arena
+from constants import PLAYER_ON_PATROL_LOOP
+from iron_math import add_vec, scale_vec, subtract_vec
+from player_manager import PlayerManager
+
+
+class DebugPatrolLoop:
+    def __init__(self, player_manager: PlayerManager, arena: Arena):
+        self.player_manager = player_manager
+        self.arena = arena
+        self.patrol_timer = 0.0
+
+    def update(self, delta_time: float):
+        # skip if not enabled
+        if PLAYER_ON_PATROL_LOOP is None:
+            return
+        self.patrol_timer += delta_time
+        if self.patrol_timer >= self.arena._patrol_loop.max_time:
+            self.patrol_timer = self.arena._patrol_loop.min_time
+        player = self.player_manager.players[PLAYER_ON_PATROL_LOOP]
+        position = self.arena._patrol_loop.sample(self.patrol_timer)
+        position_soon = self.arena._patrol_loop.sample(self.patrol_timer + 0.2)
+        heading_vec = subtract_vec(position_soon, position)
+        heading_radians = math.atan2(heading_vec[1], heading_vec[0])
+        player.location = (position[0], position[1], heading_radians)

--- a/src/iron_math.py
+++ b/src/iron_math.py
@@ -46,6 +46,19 @@ def add_vec(*vectors: Tuple[float, float]):
     return (x, y)
 
 
+def subtract_vec(vector_a: tuple[float, float], vector_b: tuple[float, float], /):
+    """
+    Subtract vector_b from vector_a, getting the relative vector pointing from b to a.
+
+    vector_a = (x, y)
+
+    vector_b = (x, y)
+
+    Returns (x, y)
+    """
+    return (vector_a[0] - vector_b[0], vector_a[1] - vector_b[1])
+
+
 def scale_vec(vector: Tuple[float, float], factor: float, /):
     """
     Scale a 2d vector by a given factor.

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from arena.arena import Arena
 from arena.arena_loader import load_arena_by_name
 from collision import projectile_hits_player, projectile_hits_wall
 from constants import (
+    ARENA,
     SCREEN_HEIGHT,
     SCREEN_TITLE,
     SCREEN_WIDTH,
@@ -43,7 +44,7 @@ class MyGame(arcade.Window):
         self.projectile_sprite_list = arcade.SpriteList()
 
         # Arena
-        self.arena = load_arena_by_name("default")
+        self.arena = load_arena_by_name(ARENA)
         self.arena.init_for_drawing(self.sprite_lists)
 
         # Players

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import arcade
 
 from arena.arena import Arena
@@ -56,6 +57,7 @@ class MyGame(arcade.Window):
 
         # Player Huds
         self.hud = Hud(self.player_manager.players, self.sprite_lists)
+        self.patrol_timer = 0.0
 
     def on_update(self, delta_time):
         # Arcade engine has a quirk where, in the debugger, it calls `on_update` twice back-to-back,
@@ -79,6 +81,12 @@ class MyGame(arcade.Window):
         )
         projectile_hits_wall(self.sprite_lists)
         projectile_hits_player(delta_time, self.sprite_lists)
+        self.patrol_timer += delta_time
+        if self.patrol_timer >= self.arena._patrol_loop.max_time:
+            self.patrol_timer = self.arena._patrol_loop.min_time
+        self.player_manager.players[1].sprite.position = self.arena._patrol_loop.sample(
+            self.patrol_timer
+        )
         self.hud.update()
 
     def on_draw(self):

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from constants import (
     TICK_DURATION,
     USE_DEBUGGER_TIMING_FIXES,
 )
+from debug_patrol_loop import DebugPatrolLoop
 from fullscreen import FullscreenController
 from global_input import GlobalInput, bind_global_inputs_to_keyboard
 from hud import Hud
@@ -58,7 +59,9 @@ class MyGame(arcade.Window):
 
         # Player Huds
         self.hud = Hud(self.player_manager.players, self.sprite_lists)
-        self.patrol_timer = 0.0
+
+        # Debug thingie that puppeteers a player on a patrol loop
+        self.debug_patrol_loop = DebugPatrolLoop(self.player_manager, self.arena)
 
     def on_update(self, delta_time):
         # Arcade engine has a quirk where, in the debugger, it calls `on_update` twice back-to-back,
@@ -76,18 +79,13 @@ class MyGame(arcade.Window):
         self.player_manager.update_inputs()
         for player in self.player_manager.players:
             player.update(delta_time)
+        self.debug_patrol_loop.update(delta_time)
         update_projectiles(
             delta_time,
             self.sprite_lists,
         )
         projectile_hits_wall(self.sprite_lists)
         projectile_hits_player(delta_time, self.sprite_lists)
-        self.patrol_timer += delta_time
-        if self.patrol_timer >= self.arena._patrol_loop.max_time:
-            self.patrol_timer = self.arena._patrol_loop.min_time
-        self.player_manager.players[1].sprite.position = self.arena._patrol_loop.sample(
-            self.patrol_timer
-        )
         self.hud.update()
 
     def on_draw(self):

--- a/src/path.py
+++ b/src/path.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from curve import Curve
+
+
+class Path:
+    """
+    Hacky combination of two Curves to produce a timeline of 2d vectors.
+    """
+
+    def __init__(self, points: list[tuple[float, float, float]] = []):
+        x_points = [(t[0], t[1]) for t in points]
+        y_points = [(t[0], t[2]) for t in points]
+        self._x_curve = Curve(x_points)
+        self._y_curve = Curve(y_points)
+
+    @property
+    def min_time(self):
+        return self._x_curve.points[0][0]
+
+    @property
+    def max_time(self):
+        return self._x_curve.points[-1][0]
+
+    def sample(self, sample_time: float):
+        return (self._x_curve.sample(sample_time), self._y_curve.sample(sample_time))


### PR DESCRIPTION
When enabled in `constants.py`, one of the players moves automatically along a set patrol loop, giving us a moving target to shoot at for testing things.

The waypoints that it follows are placed in the map editor, so they can be tweaked by anyone.  In the map editor they appear as a pin with an arrow pointing to the next pin in the loop.  The game will likely crash on startup if this loop is not set correctly in the map editor.

The puppeteered car's speed and heading are not realistic, but it at least kinda points in the direction it's moving.

The `arena_loader` has new code to load the waypoints.

I added a new `Path` class which is like a `Curve`, but it returns `(x, y)` vectors instead of a scalar.

I added `subtract_vec(vector_a, vector_b)` to iron_math.

Unrelated, but I also made a `constants.py` value for the arena to be loaded.  This is not necessary for the patrol loop stuff, it just seemed like a nice change to sneak in.