### PR TITLE
Add git commit hook to verify formatting when committing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,5 @@ uninstall-git-hooks:
 
 # This is run by the pre-commit hook to verify formatting
 .PHONY: pre-commit
-pre-commit: check
+pre-commit:
+	@python scripts/pre-commit.py

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ lint:
 # match the formatter.  `make fmt` or Ctrl+Shift+B can fix this.
 .PHONY: install-git-hooks
 install-git-hooks:
-	bash -c "echo $$'#!/usr/bin/env bash\nmake check' > .git/hooks/pre-commit"
+	python scripts/install-git-hooks.py
 
 # Uninstall the pre-commit hook
 .PHONY: uninstall-git-hooks
 uninstall-git-hooks:
-	bash -c 'rm .git/hooks/pre-commit'
+	python scripts/uninstall-git-hooks.py
 
 # This is run by the pre-commit hook to verify formatting
 .PHONY: pre-commit

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,19 @@ check: lint
 lint:
 	python -m isort --check .
 	python -m black --check $(formatSources)
+
+# Run to install a git pre-commit hook.
+# If installed, committing will error-out when code doesn't
+# match the formatter.  `make fmt` or Ctrl+Shift+B can fix this.
+.PHONY: install-git-hooks
+install-git-hooks:
+	bash -c "echo $$'#!/usr/bin/env bash\nmake check' > .git/hooks/pre-commit"
+
+# Uninstall the pre-commit hook
+.PHONY: uninstall-git-hooks
+uninstall-git-hooks:
+	bash -c 'rm .git/hooks/pre-commit'
+
+# This is run by the pre-commit hook to verify formatting
+.PHONY: pre-commit
+pre-commit: check

--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ Getting started on Windows:
 Restart VSCode to detect installed changes.
 
 At this point, you should be able to press F5 in VSCode and for the game to launch.
+
+### Install git commit hook (optional)
+
+It's easy to forget to run the formatter.  When configured,
+git can double-check this every time we commit.  We have a
+makefile target to configure this:
+
+```shell
+make install-git-hooks
+```
+
+This will install a git pre-commit hook.  When installed, git commit will error
+when code doesn't match the formatter.  This is a reminder to press Ctrl+Shift+B
+and commit the newly-formatted code.
+
+It works by telling git to run `make check` every time you commit.  See the
+`Makefile` for details.

--- a/scripts/install-git-hooks.py
+++ b/scripts/install-git-hooks.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+f = open('.git/hooks/pre-commit', 'w')
+f.write('#!/usr/bin/env bash\n')
+f.write('make check')
+f.close()

--- a/scripts/install-git-hooks.py
+++ b/scripts/install-git-hooks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-f = open('.git/hooks/pre-commit', 'w')
-f.write('#!/usr/bin/env bash\n')
-f.write('make check')
+f = open(".git/hooks/pre-commit", "w")
+f.write("#!/usr/bin/env bash\n")
+f.write("make pre-commit")
 f.close()

--- a/scripts/pre-commit.py
+++ b/scripts/pre-commit.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import subprocess
+
+result = subprocess.run("make check", capture_output=True)
+if result.returncode != 0:
+    print(
+        "Pre-commit hook found unformatted code.  Running the formatter should fix it. Ctrl+Shift+B in VSCode, or run 'make fmt' in your terminal."
+    )
+    print("")
+    print(result.stdout.decode("utf-8"))
+    print(result.stderr.decode("utf-8"))
+    exit(result.returncode)

--- a/scripts/uninstall-git-hooks.py
+++ b/scripts/uninstall-git-hooks.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+import os
+
+os.remove(".git/hooks/pre-commit")

--- a/src/foo.py
+++ b/src/foo.py
@@ -1,1 +1,0 @@
-askldjflaksdjf

--- a/src/foo.py
+++ b/src/foo.py
@@ -1,0 +1,1 @@
+askldjflaksdjf


### PR DESCRIPTION
Explanation is in the README.  `make install-git-hooks` to try it out, then attempt to commit some un-formatted code.  It should fail.

Super-nitpicky thing:
Technically, this runs the formatter against the working tree, not the staged changes.  So you might hit issues where you're committing badly formatted code and this check will not prevent it, or vice versa.  I didn't think it was worth implementing a check against the git index.