### PR TITLE
Player vehicle distinction

### DIFF
--- a/src/collision.py
+++ b/src/collision.py
@@ -18,14 +18,14 @@ def ordnance_hits_wall(sprite_lists: SpriteLists):
             ordnance_sprite.owner.on_collision_with_wall(walls_touching_ordnance)
 
 
-def ordnance_hits_player(delta_time, sprite_lists: SpriteLists):
+def ordnance_hits_vehicle(delta_time, sprite_lists: SpriteLists):
     for ordnance_sprite in sprite_lists.ordnance:
         ordnance_sprite: LinkedSprite[Ordnance]
-        players_touching_ordnance = arcade.check_for_collision_with_list(
-            ordnance_sprite, sprite_lists.players
+        vehicles_touching_ordnance = arcade.check_for_collision_with_list(
+            ordnance_sprite, sprite_lists.vehicles
         )
 
-        if len(players_touching_ordnance) > 0:
-            ordnance_sprite.owner.on_collision_with_player(
-                delta_time, players_touching_ordnance
+        if len(vehicles_touching_ordnance) > 0:
+            ordnance_sprite.owner.on_collision_with_vehicle(
+                delta_time, vehicles_touching_ordnance
             )

--- a/src/debug_hud.py
+++ b/src/debug_hud.py
@@ -45,7 +45,7 @@ class DebugHud:
             player_input = player.input
             lines += [f"Player #{index + 1}"]
             if DRAW_DRIVE_MODE_DEBUG_HUD:
-                lines += [f"Drive mode: {player.drive_mode.name}"]
+                lines += [f"Drive mode: {player.vehicle.drive_mode.name}"]
             if DRAW_INPUT_DEBUG_HUD:
                 lines += [f"Layout: {player_input.layout_name}"]
                 lines += [

--- a/src/debug_patrol_loop.py
+++ b/src/debug_patrol_loop.py
@@ -32,4 +32,4 @@ class DebugPatrolLoop:
         position_soon = self.arena.patrol_loop.sample(patrol_timer_soon)
         heading_vec = subtract_vec(position_soon, position)
         heading_radians = math.atan2(heading_vec[1], heading_vec[0])
-        player.location = (position[0], position[1], heading_radians)
+        player.vehicle.location = (position[0], position[1], heading_radians)

--- a/src/driving/drifty_car.py
+++ b/src/driving/drifty_car.py
@@ -98,10 +98,10 @@ class DriftyCar(DriveMode):
         """
 
     def drive(self, delta_time: float):
-        prev_location = self.player.location
+        prev_location = self.vehicle.location
         prev_position = prev_location[:2]
         prev_rotation = prev_location[2]
-        prev_velocity = self.player.velocity
+        prev_velocity = self.vehicle.velocity
 
         # Holding both gas and reverse means you're in "drift mode"
         drifting = (
@@ -200,7 +200,7 @@ class DriftyCar(DriveMode):
 
         # apply delta-time-d acceleration to velocity
         new_velocity = add_vec(prev_velocity, scale_vec(acceleration, delta_time))
-        self.player.velocity = new_velocity
+        self.vehicle.velocity = new_velocity
 
         # apply delta-time-d velocity to position
         new_position = add_vec(prev_position, scale_vec(new_velocity, delta_time))
@@ -222,4 +222,4 @@ class DriftyCar(DriveMode):
         new_rotation = prev_rotation + angular_velocity * delta_time
 
         # Apply movement to the sprite
-        self.player.location = (new_position[0], new_position[1], new_rotation)
+        self.vehicle.location = (new_position[0], new_position[1], new_rotation)

--- a/src/driving/drive_mode.py
+++ b/src/driving/drive_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class DriveMode:
@@ -11,9 +11,9 @@ class DriveMode:
     Abstract class that tells a car how to drive around.
     """
 
-    def __init__(self, player: Player):
-        self.player = player
-        self.input = self.player.input
+    def __init__(self, vehicle: Vehicle):
+        self.vehicle = vehicle
+        self.input = self.vehicle.player.input
         self.name = "unnamed"
         self.setup()
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import arcade
 
 from arena.arena import Arena
 from arena.arena_loader import load_arena_by_name
-from collision import ordnance_hits_player, ordnance_hits_wall
+from collision import ordnance_hits_vehicle, ordnance_hits_wall
 from constants import (
     ARENA,
     SCREEN_HEIGHT,
@@ -85,7 +85,7 @@ class MyGame(arcade.Window):
             self.sprite_lists,
         )
         ordnance_hits_wall(self.sprite_lists)
-        ordnance_hits_player(delta_time, self.sprite_lists)
+        ordnance_hits_vehicle(delta_time, self.sprite_lists)
         self.hud.update()
 
     def on_draw(self):
@@ -95,8 +95,6 @@ class MyGame(arcade.Window):
         # clear screen
         self.clear()
         self.sprite_lists.draw()
-        for player in self.player_manager.players:
-            player.draw()
         self.input_debug_hud.draw()
 
 

--- a/src/movement_controls.py
+++ b/src/movement_controls.py
@@ -177,7 +177,7 @@ class MovementControls:
             vehicle.location = (
                 vehicle.center_x % self.debug_world_boundary,
                 vehicle.center_y % self.debug_world_boundary,
-                self.shadow_sprite.radians,
+                vehicle.radians,
             )
 
     def clamp(self, num, min_value, max_value):

--- a/src/movement_controls.py
+++ b/src/movement_controls.py
@@ -130,6 +130,12 @@ class MovementControls:
             * -self.current_acceleration
         )
 
+    def reset_velocity(self):
+        self.current_acceleration = 0
+        self.current_velocity_x = 0
+        self.current_velocity_y = 0
+        self.current_velocity_turn = 0
+
     # called from the player to tell the vehicle to act on it's intended velocity and rotation
     def move(self, delta_time: float, walls: arcade.SpriteList):
         # the shadow sprite is used to simply math and planning to deal with the arena not being an array

--- a/src/movement_controls.py
+++ b/src/movement_controls.py
@@ -52,8 +52,7 @@ class MovementControls:
     current_velocity_turn: float
     current_acceleration: float
 
-    def __init__(self, vehicle: Vehicle, sprite: arcade.Sprite):
-        self.vehicle = vehicle
+    def __init__(self, sprite: arcade.Sprite):
         self.shadow_sprite = sprite
         self.shadow_sprite.center_x = sprite.center_x
         self.shadow_sprite.center_y = sprite.center_y
@@ -75,7 +74,7 @@ class MovementControls:
     #   Drive input is called by the player and passed that player's input
     #   to set what the vehicle's velocity and rotation should be
     #   Does not change the vehicles position
-    def drive_input(self, delta_time: float, input: PlayerInput):
+    def drive_input(self, delta_time: float, vehicle: Vehicle, input: PlayerInput):
 
         if self.impact_buffer > 0:
             self.impact_buffer -= 1
@@ -84,8 +83,8 @@ class MovementControls:
 
         # updates the vehicles intended  velocity and rotation based on type
         acceleration_change = 0
-        self.shadow_sprite.center_x = self.vehicle.center_x
-        self.shadow_sprite.center_y = self.vehicle.center_y
+        self.shadow_sprite.center_x = vehicle.center_x
+        self.shadow_sprite.center_y = vehicle.center_y
 
         if input.accelerate_axis.value:
             if self.current_acceleration < 0:
@@ -106,7 +105,7 @@ class MovementControls:
             self.current_acceleration + (acceleration_change * delta_time), -1, 1
         )
 
-        car_angle = math.radians(self.vehicle.angle)
+        car_angle = math.radians(vehicle.angle)
 
         # find the X and Y movement based on the angle of the sprite
         self.current_velocity_x = (
@@ -137,14 +136,12 @@ class MovementControls:
         self.current_velocity_turn = 0
 
     # called from the player to tell the vehicle to act on it's intended velocity and rotation
-    def move(self, delta_time: float, walls: arcade.SpriteList):
+    def move(self, delta_time: float, vehicle: Vehicle, walls: arcade.SpriteList):
         # the shadow sprite is used to simply math and planning to deal with the arena not being an array
-        self.shadow_sprite.center_x = self.vehicle.center_x + self.current_velocity_x
-        self.shadow_sprite.center_y = self.vehicle.center_y + self.current_velocity_y
+        self.shadow_sprite.center_x = vehicle.center_x + self.current_velocity_x
+        self.shadow_sprite.center_y = vehicle.center_y + self.current_velocity_y
         self.shadow_sprite.angle = (
-            self.current_velocity_turn
-            + self.vehicle.angle
-            + self.external_velocity_turn
+            self.current_velocity_turn + vehicle.angle + self.external_velocity_turn
         )
         walls_touching_player = arcade.check_for_collision_with_list(
             self.shadow_sprite, walls
@@ -165,11 +162,11 @@ class MovementControls:
                     self.current_velocity_x = 0
                     self.current_velocity_y = 0
 
-            self.shadow_sprite.center_x = self.vehicle.center_x
-            self.shadow_sprite.center_y = self.vehicle.center_y
+            self.shadow_sprite.center_x = vehicle.center_x
+            self.shadow_sprite.center_y = vehicle.center_y
         else:
             # no wall collisions means a valid spot to move to
-            self.vehicle.location = (
+            vehicle.location = (
                 self.shadow_sprite.center_x,
                 self.shadow_sprite.center_y,
                 self.shadow_sprite.radians,
@@ -177,9 +174,9 @@ class MovementControls:
 
         # NOTE: place holder boundaries to wrap aroung like pacman
         if self.debug_world_boundary != 0:
-            self.vehicle.location = (
-                self.vehicle.center_x % self.debug_world_boundary,
-                self.vehicle.center_y % self.debug_world_boundary,
+            vehicle.location = (
+                vehicle.center_x % self.debug_world_boundary,
+                vehicle.center_y % self.debug_world_boundary,
                 self.shadow_sprite.radians,
             )
 

--- a/src/movement_controls.py
+++ b/src/movement_controls.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 #
 # for checking if a vehicle should take damage from an impact. as a percentage of their top acceleration
 
-DEFAULT_WORLD_SIZE = constants.SCREEN_WIDTH
+DEFAULT_WORLD_SIZE_X = constants.SCREEN_WIDTH
+DEFAULT_WORLD_SIZE_Y = constants.SCREEN_HEIGHT
 DEFAULT_ACCELERATION_RATE = 2.5
 DEFAULT_BRAKE_RATE = 0.8
 DEFAULT_FRICTION = 0.1
@@ -57,7 +58,8 @@ class MovementControls:
         self.shadow_sprite.center_x = sprite.center_x
         self.shadow_sprite.center_y = sprite.center_y
         self.shadow_sprite.angle = sprite.angle
-        self.debug_world_boundary = DEFAULT_WORLD_SIZE
+        self.debug_world_boundary_x = DEFAULT_WORLD_SIZE_X
+        self.debug_world_boundary_y = DEFAULT_WORLD_SIZE_Y
         self.current_velocity_x = 0
         self.current_velocity_y = 0
         self.current_velocity_turn = 0
@@ -173,10 +175,10 @@ class MovementControls:
             )
 
         # NOTE: place holder boundaries to wrap aroung like pacman
-        if self.debug_world_boundary != 0:
+        if self.debug_world_boundary_x != 0:
             vehicle.location = (
-                vehicle.center_x % self.debug_world_boundary,
-                vehicle.center_y % self.debug_world_boundary,
+                vehicle.center_x % self.debug_world_boundary_x,
+                vehicle.center_y % self.debug_world_boundary_y,
                 vehicle.radians,
             )
 

--- a/src/movement_controls.py
+++ b/src/movement_controls.py
@@ -52,7 +52,8 @@ class MovementControls:
     current_velocity_turn: float
     current_acceleration: float
 
-    def __init__(self, sprite: arcade.Sprite):
+    def __init__(self, vehicle: Vehicle, sprite: arcade.Sprite):
+        self.vehicle = vehicle
         self.shadow_sprite = sprite
         self.shadow_sprite.center_x = sprite.center_x
         self.shadow_sprite.center_y = sprite.center_y
@@ -74,9 +75,7 @@ class MovementControls:
     #   Drive input is called by the player and passed that player's input
     #   to set what the vehicle's velocity and rotation should be
     #   Does not change the vehicles position
-    def drive_input(
-        self, delta_time: float, input: PlayerInput, vehicle: arcade.Sprite
-    ):
+    def drive_input(self, delta_time: float, input: PlayerInput):
 
         if self.impact_buffer > 0:
             self.impact_buffer -= 1
@@ -85,8 +84,8 @@ class MovementControls:
 
         # updates the vehicles intended  velocity and rotation based on type
         acceleration_change = 0
-        self.shadow_sprite.center_x = vehicle.center_x
-        self.shadow_sprite.center_y = vehicle.center_y
+        self.shadow_sprite.center_x = self.vehicle.center_x
+        self.shadow_sprite.center_y = self.vehicle.center_y
 
         if input.accelerate_axis.value:
             if self.current_acceleration < 0:
@@ -107,7 +106,7 @@ class MovementControls:
             self.current_acceleration + (acceleration_change * delta_time), -1, 1
         )
 
-        car_angle = math.radians(vehicle.angle)
+        car_angle = math.radians(self.vehicle.angle)
 
         # find the X and Y movement based on the angle of the sprite
         self.current_velocity_x = (
@@ -132,13 +131,13 @@ class MovementControls:
         )
 
     # called from the player to tell the vehicle to act on it's intended velocity and rotation
-    def move(self, delta_time: float, vehicle: Vehicle, walls: arcade.SpriteList):
+    def move(self, delta_time: float, walls: arcade.SpriteList):
         # the shadow sprite is used to simply math and planning to deal with the arena not being an array
-        self.shadow_sprite.center_x = vehicle.sprite.center_x + self.current_velocity_x
-        self.shadow_sprite.center_y = vehicle.sprite.center_y + self.current_velocity_y
+        self.shadow_sprite.center_x = self.vehicle.center_x + self.current_velocity_x
+        self.shadow_sprite.center_y = self.vehicle.center_y + self.current_velocity_y
         self.shadow_sprite.angle = (
             self.current_velocity_turn
-            + vehicle.sprite.angle
+            + self.vehicle.angle
             + self.external_velocity_turn
         )
         walls_touching_player = arcade.check_for_collision_with_list(
@@ -160,11 +159,11 @@ class MovementControls:
                     self.current_velocity_x = 0
                     self.current_velocity_y = 0
 
-            self.shadow_sprite.center_x = vehicle.sprite.center_x
-            self.shadow_sprite.center_y = vehicle.sprite.center_y
+            self.shadow_sprite.center_x = self.vehicle.center_x
+            self.shadow_sprite.center_y = self.vehicle.center_y
         else:
             # no wall collisions means a valid spot to move to
-            vehicle.location = (
+            self.vehicle.location = (
                 self.shadow_sprite.center_x,
                 self.shadow_sprite.center_y,
                 self.shadow_sprite.radians,
@@ -172,9 +171,9 @@ class MovementControls:
 
         # NOTE: place holder boundaries to wrap aroung like pacman
         if self.debug_world_boundary != 0:
-            vehicle.location = (
-                vehicle.sprite.center_x % self.debug_world_boundary,
-                vehicle.sprite.center_y % self.debug_world_boundary,
+            self.vehicle.location = (
+                self.vehicle.center_x % self.debug_world_boundary,
+                self.vehicle.center_y % self.debug_world_boundary,
                 self.shadow_sprite.radians,
             )
 

--- a/src/ordnances/beam.py
+++ b/src/ordnances/beam.py
@@ -62,7 +62,7 @@ class Beam(Ordnance):
             vehicles_touching_projectile
         )
         if vehicle_sprite != None:
-            vehicle_sprite.owner.player.take_damage(self.dps * delta_time)
+            vehicle_sprite.owner.apply_damage(self.dps * delta_time)
 
     def _shorten_beam(self, collision_list: list[LinkedSprite]):
         """

--- a/src/ordnances/beam.py
+++ b/src/ordnances/beam.py
@@ -16,9 +16,8 @@ from ordnances.ordnance import Ordnance
 from sprite_lists import SpriteLists
 
 # This allows a circular import only for the purposes of type hints
-# Weapon will never create and instance of Player
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class Beam(Ordnance):
@@ -54,12 +53,16 @@ class Beam(Ordnance):
     ):
         self._shorten_beam(walls_touching_projectile)
 
-    def on_collision_with_player(
-        self, delta_time: float, players_touching_projectile: list[LinkedSprite[Player]]
+    def on_collision_with_vehicle(
+        self,
+        delta_time: float,
+        vehicles_touching_projectile: list[LinkedSprite[Vehicle]],
     ):
-        player: LinkedSprite[Player] = self._shorten_beam(players_touching_projectile)
-        if player != None:
-            player.owner.take_damage(self.dps * delta_time)
+        vehicle_sprite: LinkedSprite[Vehicle] = self._shorten_beam(
+            vehicles_touching_projectile
+        )
+        if vehicle_sprite != None:
+            vehicle_sprite.owner.player.take_damage(self.dps * delta_time)
 
     def _shorten_beam(self, collision_list: list[LinkedSprite]):
         """

--- a/src/ordnances/explosion.py
+++ b/src/ordnances/explosion.py
@@ -119,5 +119,5 @@ class SubExplosion(Ordnance):
     ):
         for vehicle_sprite in vehicles_touching_projectile:
             if vehicle_sprite.owner not in self.explosion.vehicles_hit:
-                vehicle_sprite.owner.player.take_damage(self.damage)
+                vehicle_sprite.owner.apply_damage(self.damage)
                 self.explosion.vehicles_hit.append(vehicle_sprite.owner)

--- a/src/ordnances/explosion.py
+++ b/src/ordnances/explosion.py
@@ -12,9 +12,8 @@ from ordnances.ordnance import Ordnance
 from sprite_lists import SpriteLists
 
 # This allows a circular import only for the purposes of type hints
-# Weapon will never create and instance of Player
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class Explosion(Ordnance):
@@ -22,7 +21,7 @@ class Explosion(Ordnance):
     explosion_rate: float
     explosion_radius: float
     current_radius: float
-    players_hit: list[Player]
+    vehicles_hit: list[Vehicle]
 
     def __init__(
         self,
@@ -43,7 +42,7 @@ class Explosion(Ordnance):
         self.explosion_radius = explosion_radius
         self.explosion_rate = explosion_rate
         self.current_radius = 1
-        self.players_hit = []
+        self.vehicles_hit = []
         # Make a list of all directions in radians in pi/16 (11.25 degree) increments
         directions = [x * (math.pi / 16) for x in range(-16, 16)]
         for direction in directions:
@@ -113,10 +112,12 @@ class SubExplosion(Ordnance):
     ):
         self.explosion_rate = 0
 
-    def on_collision_with_player(
-        self, delta_time: float, players_touching_projectile: list[LinkedSprite[Player]]
+    def on_collision_with_vehicle(
+        self,
+        delta_time: float,
+        vehicles_touching_projectile: list[LinkedSprite[Vehicle]],
     ):
-        for player_sprite in players_touching_projectile:
-            if player_sprite.owner not in self.explosion.players_hit:
-                player_sprite.owner.take_damage(self.damage)
-                self.explosion.players_hit.append(player_sprite.owner)
+        for vehicle_sprite in vehicles_touching_projectile:
+            if vehicle_sprite.owner not in self.explosion.vehicles_hit:
+                vehicle_sprite.owner.player.take_damage(self.damage)
+                self.explosion.vehicles_hit.append(vehicle_sprite.owner)

--- a/src/ordnances/ordnance.py
+++ b/src/ordnances/ordnance.py
@@ -4,15 +4,13 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 import arcade
 
-from arena.wall import Wall
 from iron_math import set_sprite_location
-from linked_sprite import LinkedSprite, LinkedSpriteCircle
+from linked_sprite import LinkedSprite
 from sprite_lists import SpriteLists
 
 # This allows a circular import only for the purposes of type hints
-# Weapon will never create and instance of Player
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class Ordnance:
@@ -77,8 +75,10 @@ class Ordnance:
     def on_collision_with_wall(self, walls_touching_projectile: arcade.SpriteList):
         ...
 
-    def on_collision_with_player(
-        self, delta_time: float, players_touching_projectile: list[LinkedSprite[Player]]
+    def on_collision_with_vehicle(
+        self,
+        delta_time: float,
+        vehicles_touching_projectile: list[LinkedSprite[Vehicle]],
     ):
         ...
 

--- a/src/ordnances/projectile.py
+++ b/src/ordnances/projectile.py
@@ -11,9 +11,8 @@ from ordnances.ordnance import Ordnance
 from sprite_lists import SpriteLists
 
 # This allows a circular import only for the purposes of type hints
-# Weapon will never create and instance of Player
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class Projectile(Ordnance):
@@ -56,11 +55,13 @@ class Projectile(Ordnance):
         self.remove_sprite()
         self.activate_payload()
 
-    def on_collision_with_player(
-        self, delta_time: float, players_touching_projectile: list[LinkedSprite[Player]]
+    def on_collision_with_vehicle(
+        self,
+        delta_time: float,
+        vehicles_touching_projectile: list[LinkedSprite[Vehicle]],
     ):
-        for player_sprite in players_touching_projectile:
-            player_sprite: LinkedSprite[Player]
-            player_sprite.owner.take_damage(self.damage)
+        for vehicle_sprite in vehicles_touching_projectile:
+            vehicle_sprite: LinkedSprite[Vehicle]
+            vehicle_sprite.owner.player.take_damage(self.damage)
         self.remove_sprite()
         self.activate_payload()

--- a/src/ordnances/projectile.py
+++ b/src/ordnances/projectile.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 import arcade
 
-from arena.wall import Wall
 from iron_math import move_sprite_polar, set_sprite_location, sprite_in_bounds
-from linked_sprite import LinkedSprite, LinkedSpriteCircle
+from linked_sprite import LinkedSprite
 from ordnances.ordnance import Ordnance
 from sprite_lists import SpriteLists
 

--- a/src/ordnances/projectile.py
+++ b/src/ordnances/projectile.py
@@ -62,6 +62,6 @@ class Projectile(Ordnance):
     ):
         for vehicle_sprite in vehicles_touching_projectile:
             vehicle_sprite: LinkedSprite[Vehicle]
-            vehicle_sprite.owner.player.take_damage(self.damage)
+            vehicle_sprite.owner.apply_damage(self.damage)
         self.remove_sprite()
         self.activate_payload()

--- a/src/player.py
+++ b/src/player.py
@@ -6,6 +6,7 @@ from typing import List
 
 import arcade
 
+from arena.spawn_point import SpawnPoint
 from constants import SCREEN_HEIGHT, SCREEN_WIDTH
 from driving.create_drive_modes import create_drive_modes
 from iron_math import get_sprite_location, set_sprite_location
@@ -14,6 +15,7 @@ from movement_controls import MovementControls
 from player_input import PlayerInput
 from sprite_lists import SpriteLists
 from textures import RED_CAR
+from vehicle import Vehicle
 from weapons.laser_beam import LaserBeam
 from weapons.machine_gun import MachineGun
 from weapons.rocket_launcher import RocketLauncher
@@ -22,104 +24,27 @@ from weapons.weapon import Weapon
 
 class Player:
     def __init__(
-        self, input: PlayerInput, sprite_lists: SpriteLists, initial_spawn_points: list
+        self,
+        input: PlayerInput,
+        sprite_lists: SpriteLists,
+        initial_spawn_points: list[SpawnPoint],
+        player_index: int,
     ):
-        self.sprite = LinkedSprite[Player](texture=RED_CAR, scale=0.2)
-        self.sprite.owner = self
-        self.sprite.center_x = 256
-        self.sprite.center_y = 256
-        self.input = input
-        self.sprite_lists = sprite_lists
-        self.primary_weapon_transform = (16, 10, 0)
-        self.secondary_weapon_transform = (16, -10, 0)
-        # Weapons
-        self.weapons_list: List[Weapon] = [
-            LaserBeam,
-            RocketLauncher,
-            MachineGun,
-        ]
-        self.weapon_index = 0
-        self.primary_weapon: Weapon
-        self.secondary_weapon: Weapon
-        self.primary_weapon_sprite: arcade.Sprite
-        self.secondary_weapon_sprite: arcade.Sprite
-        self._swap_in_weapons()
+        self.vehicle = Vehicle(self, input, sprite_lists)
+        self.vehicle.location = initial_spawn_points[player_index].transform
         self.player_health = 100
         self.alive = True
         self.respawn_time_passed: float = 0
         self.time_to_respawn: float = 5
         self.initial_spawn_points = initial_spawn_points
-        self.x_shift = float
-        self.y_shift = float
-
-        self.drive_mode_index = 0
-        self.drive_modes = create_drive_modes(self)
-        self.velocity = (0.0, 0.0)
-        "Translational velocity -- (x,y) tuple -- measured in pixels per second"
-
-        self.vehicle = MovementControls(
-            LinkedSprite[Player](texture=RED_CAR, scale=0.18)
-        )
 
     def update(self, delta_time: float):
-        #
-        # Driving and movement
-        #
-        if self.alive:
-            self.vehicle.drive_input(delta_time, self.input, self.sprite)
-        self.vehicle.move(delta_time, self.sprite, self.sprite_lists.walls)
-
-        #
-        # Weapons
-        #
-        if self.alive:
-            self.primary_weapon.update(delta_time)
-            self.secondary_weapon.update(delta_time)
-            if self.input.swap_weapons_button.pressed:
-                self._swap_weapons()
-
+        self.vehicle.update(delta_time)
         #
         # Respawn
         #
         if self.player_health <= 0:
             self.die(delta_time)
-
-    @property
-    def drive_mode(self):
-        return self.drive_modes[self.drive_mode_index]
-
-    def _swap_drive_mode(self):
-        self.drive_mode_index += 1
-        if self.drive_mode_index >= len(self.drive_modes):
-            self.drive_mode_index = 0
-
-    def _swap_weapons(self):
-        # Moves the current secondary weapon to the primary weapon slot and the next weapon on the list becomes the secondary weapon
-        self._swap_out_weapons()
-        self._swap_in_weapons()
-
-    def _swap_out_weapons(self):
-        self.primary_weapon.swap_out()
-        self.secondary_weapon.swap_out()
-
-    def _swap_in_weapons(self):
-        self.primary_weapon = self.weapons_list[self.weapon_index](
-            self,
-            self.input.primary_fire_button,
-            self.primary_weapon_transform,
-        )
-        self.weapon_index += 1
-        if self.weapon_index >= len(self.weapons_list):
-            self.weapon_index = 0
-        self.secondary_weapon = self.weapons_list[self.weapon_index](
-            self,
-            self.input.secondary_fire_button,
-            self.secondary_weapon_transform,
-        )
-
-    def draw(self):
-        self.primary_weapon.draw()
-        self.secondary_weapon.draw()
 
     def take_damage(self, damage: float):
         self.player_health -= damage
@@ -139,12 +64,12 @@ class Player:
         chosen_spawn_point = self.initial_spawn_points[
             random.randrange(len(self.initial_spawn_points))
         ].transform
-        set_sprite_location(self.sprite, chosen_spawn_point)
+        set_sprite_location(self.vehicle.sprite, chosen_spawn_point)
 
     @property
-    def location(self):
-        return get_sprite_location(self.sprite)
+    def input(self):
+        return self.vehicle.input
 
-    @location.setter
-    def location(self, location: tuple[float, float, float]):
-        return set_sprite_location(self.sprite, location)
+    @input.setter
+    def input(self, input: PlayerInput):
+        self.vehicle.input = input

--- a/src/player.py
+++ b/src/player.py
@@ -1,25 +1,11 @@
 from __future__ import annotations
 
-import math
 import random
-from typing import List
-
-import arcade
 
 from arena.spawn_point import SpawnPoint
-from constants import SCREEN_HEIGHT, SCREEN_WIDTH
-from driving.create_drive_modes import create_drive_modes
-from iron_math import get_sprite_location, set_sprite_location
-from linked_sprite import LinkedSprite
-from movement_controls import MovementControls
 from player_input import PlayerInput
 from sprite_lists import SpriteLists
-from textures import RED_CAR
 from vehicle import Vehicle
-from weapons.laser_beam import LaserBeam
-from weapons.machine_gun import MachineGun
-from weapons.rocket_launcher import RocketLauncher
-from weapons.weapon import Weapon
 
 
 class Player:

--- a/src/player.py
+++ b/src/player.py
@@ -16,7 +16,8 @@ class Player:
         initial_spawn_points: list[SpawnPoint],
         player_index: int,
     ):
-        self.vehicle = Vehicle(self, input, sprite_lists)
+        self.input = input
+        self.vehicle = Vehicle(self, sprite_lists)
         self.vehicle.location = initial_spawn_points[player_index].transform
         self.player_health = 100
         self.alive = True
@@ -52,11 +53,3 @@ class Player:
         ].transform
         self.vehicle.location = chosen_spawn_point
         self.vehicle.movement.reset_velocity()
-
-    @property
-    def input(self):
-        return self.vehicle.input
-
-    @input.setter
-    def input(self, input: PlayerInput):
-        self.vehicle.input = input

--- a/src/player.py
+++ b/src/player.py
@@ -64,7 +64,8 @@ class Player:
         chosen_spawn_point = self.initial_spawn_points[
             random.randrange(len(self.initial_spawn_points))
         ].transform
-        set_sprite_location(self.vehicle.sprite, chosen_spawn_point)
+        self.vehicle.location = chosen_spawn_point
+        self.vehicle.movement.reset_velocity()
 
     @property
     def input(self):

--- a/src/player_manager.py
+++ b/src/player_manager.py
@@ -70,10 +70,9 @@ class PlayerManager:
             if player_index == KEYBOARD_PLAYER_INDEX:
                 bind_to_keyboard(player_input)
             set_controller_layout(player_input, START_WITH_ALTERNATE_CONTROLLER_LAYOUT)
-            player = Player(player_input, sprite_lists, arena.initial_spawn_points)
-            spawn_point = arena.initial_spawn_points[player_index]
-            set_sprite_location(player.sprite, spawn_point.transform)
-            sprite_lists.players.append(player.sprite)
+            player = Player(
+                player_input, sprite_lists, arena.initial_spawn_points, player_index
+            )
             self.players.append(player)
 
     def update_inputs(self):

--- a/src/sprite_lists.py
+++ b/src/sprite_lists.py
@@ -8,14 +8,16 @@ class SpriteLists:
     Structure that contains SpriteLists
     """
 
-    players: arcade.SpriteList
+    vehicles: arcade.SpriteList
+    weapons: arcade.SpriteList
     ordnance: arcade.SpriteList
     beams: arcade.SpriteList
     walls: arcade.SpriteList
     huds: arcade.SpriteList
 
     def __init__(self):
-        self.players = arcade.SpriteList()
+        self.vehicles = arcade.SpriteList()
+        self.weapons = arcade.SpriteList()
         self.ordnance = arcade.SpriteList()
         self.beams = arcade.SpriteList()
         self.walls = arcade.SpriteList()
@@ -23,7 +25,8 @@ class SpriteLists:
 
     def draw(self):
         self.walls.draw()
-        self.players.draw()
+        self.vehicles.draw()
+        self.weapons.draw()
         self.ordnance.draw()
         self.beams.draw()
         self.huds.draw()

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -8,7 +8,11 @@ import arcade
 
 from constants import SCREEN_HEIGHT, SCREEN_WIDTH
 from driving.create_drive_modes import create_drive_modes
-from iron_math import get_sprite_location, set_sprite_location
+from iron_math import (
+    get_sprite_location,
+    move_sprite_relative_to_parent,
+    set_sprite_location,
+)
 from linked_sprite import LinkedSprite
 from movement_controls import MovementControls
 from player_input import PlayerInput
@@ -65,7 +69,7 @@ class Vehicle:
         #
         if self.player.alive:
             self.movement.drive_input(delta_time, self.input, self.sprite)
-        self.movement.move(delta_time, self.sprite, self.sprite_lists.walls)
+        self.movement.move(delta_time, self, self.sprite_lists.walls)
 
         #
         # Weapons
@@ -83,6 +87,16 @@ class Vehicle:
     @location.setter
     def location(self, location: tuple[float, float, float]):
         set_sprite_location(self.sprite, location)
+        move_sprite_relative_to_parent(
+            self.primary_weapon.weapon_sprite,
+            self.sprite,
+            self.primary_weapon_transform,
+        )
+        move_sprite_relative_to_parent(
+            self.secondary_weapon.weapon_sprite,
+            self.sprite,
+            self.secondary_weapon_transform,
+        )
 
     def _swap_weapons(self):
         # Moves the current secondary weapon to the primary weapon slot and the next weapon on the list becomes the secondary weapon

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -57,7 +57,7 @@ class Vehicle:
         "Translational velocity -- (x,y) tuple -- measured in pixels per second"
 
         self.movement = MovementControls(
-            self, LinkedSprite[Vehicle](texture=RED_CAR, scale=0.18)
+            LinkedSprite[Vehicle](texture=RED_CAR, scale=0.18)
         )
 
     def update(self, delta_time: float):
@@ -65,8 +65,8 @@ class Vehicle:
         # Driving and movement
         #
         if self.player.alive:
-            self.movement.drive_input(delta_time, self.input)
-        self.movement.move(delta_time, self.sprite_lists.walls)
+            self.movement.drive_input(delta_time, self, self.input)
+        self.movement.move(delta_time, self, self.sprite_lists.walls)
 
         #
         # Weapons

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -77,6 +77,9 @@ class Vehicle:
             if self.input.swap_weapons_button.pressed:
                 self._swap_weapons()
 
+    def apply_damage(self, damage: float):
+        self.player.take_damage(damage)
+
     @property
     def location(self):
         return get_sprite_location(self.sprite)

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -57,7 +57,7 @@ class Vehicle:
         "Translational velocity -- (x,y) tuple -- measured in pixels per second"
 
         self.movement = MovementControls(
-            LinkedSprite[Vehicle](texture=RED_CAR, scale=0.18)
+            self, LinkedSprite[Vehicle](texture=RED_CAR, scale=0.18)
         )
 
     def update(self, delta_time: float):
@@ -65,8 +65,8 @@ class Vehicle:
         # Driving and movement
         #
         if self.player.alive:
-            self.movement.drive_input(delta_time, self.input, self.sprite)
-        self.movement.move(delta_time, self, self.sprite_lists.walls)
+            self.movement.drive_input(delta_time, self.input)
+        self.movement.move(delta_time, self.sprite_lists.walls)
 
         #
         # Weapons
@@ -79,24 +79,6 @@ class Vehicle:
 
     def apply_damage(self, damage: float):
         self.player.take_damage(damage)
-
-    @property
-    def location(self):
-        return get_sprite_location(self.sprite)
-
-    @location.setter
-    def location(self, location: tuple[float, float, float]):
-        set_sprite_location(self.sprite, location)
-        move_sprite_relative_to_parent(
-            self.primary_weapon.weapon_sprite,
-            self.sprite,
-            self.primary_weapon_transform,
-        )
-        move_sprite_relative_to_parent(
-            self.secondary_weapon.weapon_sprite,
-            self.sprite,
-            self.secondary_weapon_transform,
-        )
 
     def _swap_weapons(self):
         # Moves the current secondary weapon to the primary weapon slot and the next weapon on the list becomes the secondary weapon
@@ -121,6 +103,42 @@ class Vehicle:
             self.input.secondary_fire_button,
             self.secondary_weapon_transform,
         )
+
+    @property
+    def location(self):
+        return get_sprite_location(self.sprite)
+
+    @location.setter
+    def location(self, location: tuple[float, float, float]):
+        set_sprite_location(self.sprite, location)
+        move_sprite_relative_to_parent(
+            self.primary_weapon.weapon_sprite,
+            self.sprite,
+            self.primary_weapon_transform,
+        )
+        move_sprite_relative_to_parent(
+            self.secondary_weapon.weapon_sprite,
+            self.sprite,
+            self.secondary_weapon_transform,
+        )
+
+    # these properties are for the convenience of calling vehicle.center_x rather than vehicle.location[0]
+    # they specifically don't have setters because location should be set instead to move the weapons as well
+    @property
+    def center_x(self):
+        return self.sprite.center_x
+
+    @property
+    def center_y(self):
+        return self.sprite.center_y
+
+    @property
+    def angle(self):
+        return self.sprite.angle
+
+    @property
+    def radians(self):
+        return self.sprite.radians
 
     @property
     def drive_mode(self):

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import math
+import random
+from typing import TYPE_CHECKING, List
+
+import arcade
+
+from constants import SCREEN_HEIGHT, SCREEN_WIDTH
+from driving.create_drive_modes import create_drive_modes
+from iron_math import get_sprite_location, set_sprite_location
+from linked_sprite import LinkedSprite
+from movement_controls import MovementControls
+from player_input import PlayerInput
+from sprite_lists import SpriteLists
+from textures import RED_CAR
+from weapons.laser_beam import LaserBeam
+from weapons.machine_gun import MachineGun
+from weapons.rocket_launcher import RocketLauncher
+from weapons.weapon import Weapon
+
+if TYPE_CHECKING:
+    from player import Player
+
+
+class Vehicle:
+    def __init__(self, player: Player, input: PlayerInput, sprite_lists: SpriteLists):
+        self.player = player
+        self.sprite = LinkedSprite[Vehicle](texture=RED_CAR, scale=0.2)
+        self.sprite.owner = self
+        self.sprite_lists = sprite_lists
+        self.sprite_lists.vehicles.append(self.sprite)
+        self.sprite.center_x = 256
+        self.sprite.center_y = 256
+        self.input = input
+        self.primary_weapon_transform = (16, 10, 0)
+        self.secondary_weapon_transform = (16, -10, 0)
+        # Weapons
+        self.weapons_list: List[Weapon] = [
+            LaserBeam,
+            RocketLauncher,
+            MachineGun,
+        ]
+        self.weapon_index = 0
+        self.primary_weapon: Weapon
+        self.secondary_weapon: Weapon
+        self.primary_weapon_sprite: arcade.Sprite
+        self.secondary_weapon_sprite: arcade.Sprite
+        self._swap_in_weapons()
+        self.x_shift = float
+        self.y_shift = float
+
+        self.drive_mode_index = 0
+        self.drive_modes = create_drive_modes(self)
+        self.velocity = (0.0, 0.0)
+        "Translational velocity -- (x,y) tuple -- measured in pixels per second"
+
+        self.movement = MovementControls(
+            LinkedSprite[Vehicle](texture=RED_CAR, scale=0.18)
+        )
+
+    def update(self, delta_time: float):
+        #
+        # Driving and movement
+        #
+        if self.player.alive:
+            self.movement.drive_input(delta_time, self.input, self.sprite)
+        self.movement.move(delta_time, self.sprite, self.sprite_lists.walls)
+
+        #
+        # Weapons
+        #
+        if self.player.alive:
+            self.primary_weapon.update(delta_time)
+            self.secondary_weapon.update(delta_time)
+            if self.input.swap_weapons_button.pressed:
+                self._swap_weapons()
+
+    @property
+    def location(self):
+        return get_sprite_location(self.sprite)
+
+    @location.setter
+    def location(self, location: tuple[float, float, float]):
+        set_sprite_location(self.sprite, location)
+
+    def _swap_weapons(self):
+        # Moves the current secondary weapon to the primary weapon slot and the next weapon on the list becomes the secondary weapon
+        self._swap_out_weapons()
+        self._swap_in_weapons()
+
+    def _swap_out_weapons(self):
+        self.primary_weapon.swap_out()
+        self.secondary_weapon.swap_out()
+
+    def _swap_in_weapons(self):
+        self.primary_weapon = self.weapons_list[self.weapon_index](
+            self,
+            self.input.primary_fire_button,
+            self.primary_weapon_transform,
+        )
+        self.weapon_index += 1
+        if self.weapon_index >= len(self.weapons_list):
+            self.weapon_index = 0
+        self.secondary_weapon = self.weapons_list[self.weapon_index](
+            self,
+            self.input.secondary_fire_button,
+            self.secondary_weapon_transform,
+        )
+
+    @property
+    def drive_mode(self):
+        return self.drive_modes[self.drive_mode_index]
+
+    def _swap_drive_mode(self):
+        self.drive_mode_index += 1
+        if self.drive_mode_index >= len(self.drive_modes):
+            self.drive_mode_index = 0

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import math
-import random
 from typing import TYPE_CHECKING, List
 
 import arcade
 
-from constants import SCREEN_HEIGHT, SCREEN_WIDTH
 from driving.create_drive_modes import create_drive_modes
 from iron_math import (
     get_sprite_location,
@@ -109,7 +106,7 @@ class Vehicle:
 
     def _swap_in_weapons(self):
         self.primary_weapon = self.weapons_list[self.weapon_index](
-            self,
+            self.sprite_lists,
             self.input.primary_fire_button,
             self.primary_weapon_transform,
         )
@@ -117,7 +114,7 @@ class Vehicle:
         if self.weapon_index >= len(self.weapons_list):
             self.weapon_index = 0
         self.secondary_weapon = self.weapons_list[self.weapon_index](
-            self,
+            self.sprite_lists,
             self.input.secondary_fire_button,
             self.secondary_weapon_transform,
         )

--- a/src/weapons/laser_beam.py
+++ b/src/weapons/laser_beam.py
@@ -38,6 +38,7 @@ class LaserBeam(Weapon):
         self.beam.append_sprite()
 
     def swap_out(self):
+        super().swap_out()
         self.remove_beam()
 
     def remove_beam(self):

--- a/src/weapons/laser_beam.py
+++ b/src/weapons/laser_beam.py
@@ -28,7 +28,6 @@ class LaserBeam(Weapon):
         self.create_beam()
 
     def update(self, delta_time: float):
-        super().update()
         if self.input_button.pressed:
             self.shoot()
         if self.input_button.released:

--- a/src/weapons/machine_gun.py
+++ b/src/weapons/machine_gun.py
@@ -27,7 +27,6 @@ class MachineGun(Weapon):
         self.muzzle_transform = (7, 2, 0)
 
     def update(self, delta_time: float):
-        super().update()
         if self.input_button.value and self.time_since_shoot > 1 / self.fire_rate:
             self.shoot()
         self.time_since_shoot += delta_time

--- a/src/weapons/rocket_launcher.py
+++ b/src/weapons/rocket_launcher.py
@@ -36,7 +36,6 @@ class RocketLauncher(Weapon):
         self.explosion_rate = 200
 
     def update(self, delta_time: float):
-        super().update()
         if self.input_button.pressed:
             if self.time_since_shoot > 1 / self.fire_rate:
                 self.shoot()

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -1,29 +1,25 @@
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING, Tuple
 
 import arcade
 
-from iron_math import get_transformed_location, move_sprite_relative_to_parent
-from linked_sprite import LinkedSprite, LinkedSpriteCircle, LinkedSpriteSolidColor
+from iron_math import move_sprite_relative_to_parent
 from player_input import VirtualButton
 from sprite_lists import SpriteLists
-from textures import LASER_PISTOL, MACHINE_GUN, ROCKET, ROCKET_LAUNCHER
 
 # This allows a circular import only for the purposes of type hints
-# Weapon will never create and instance of Player
 if TYPE_CHECKING:
-    from player import Player
+    from vehicle import Vehicle
 
 
 class Weapon:
     """
-    Slotted into player's car and behaves according to it's subclass weapon type
+    Slotted into a vehicle and behaves according to it's subclass weapon type
     """
 
     input_button: VirtualButton
-    player: Player
+    vehicle: Vehicle
     sprite_lists: SpriteLists
     time_since_shoot: float
     weapon_icon: arcade.texture
@@ -31,16 +27,17 @@ class Weapon:
 
     def __init__(
         self,
-        player: Player,
+        vehicle: Vehicle,
         input_button: VirtualButton,
         weapon_transform: Tuple[float, float, float],
     ):
         self.input_button = input_button
-        self.player = player
-        self.sprite_lists = player.sprite_lists
+        self.vehicle = vehicle
+        self.sprite_lists = vehicle.sprite_lists
         self.weapon_transform = weapon_transform
         self.time_since_shoot = 100
         self.weapon_sprite = arcade.Sprite(texture=self.weapon_icon, scale=1)
+        self.sprite_lists.weapons.append(self.weapon_sprite)
         self.setup()
 
     def setup(self):
@@ -53,11 +50,8 @@ class Weapon:
 
     def update(self):
         move_sprite_relative_to_parent(
-            self.weapon_sprite, self.player.sprite, self.weapon_transform
+            self.weapon_sprite, self.vehicle.sprite, self.weapon_transform
         )
 
     def swap_out(self):
-        pass
-
-    def draw(self):
-        self.weapon_sprite.draw()
+        self.sprite_lists.weapons.remove(self.weapon_sprite)

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -19,7 +19,6 @@ class Weapon:
     """
 
     input_button: VirtualButton
-    vehicle: Vehicle
     sprite_lists: SpriteLists
     time_since_shoot: float
     weapon_icon: arcade.texture
@@ -27,13 +26,12 @@ class Weapon:
 
     def __init__(
         self,
-        vehicle: Vehicle,
+        sprite_lists: SpriteLists,
         input_button: VirtualButton,
         weapon_transform: Tuple[float, float, float],
     ):
         self.input_button = input_button
-        self.vehicle = vehicle
-        self.sprite_lists = vehicle.sprite_lists
+        self.sprite_lists = sprite_lists
         self.weapon_transform = weapon_transform
         self.time_since_shoot = 100
         self.weapon_sprite = arcade.Sprite(texture=self.weapon_icon, scale=1)

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import Tuple
 
 import arcade
 
-from iron_math import move_sprite_relative_to_parent
 from player_input import VirtualButton
 from sprite_lists import SpriteLists
-
-# This allows a circular import only for the purposes of type hints
-if TYPE_CHECKING:
-    from vehicle import Vehicle
 
 
 class Weapon:

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -49,9 +49,7 @@ class Weapon:
         ...
 
     def update(self):
-        move_sprite_relative_to_parent(
-            self.weapon_sprite, self.vehicle.sprite, self.weapon_transform
-        )
+        ...
 
     def swap_out(self):
         self.sprite_lists.weapons.remove(self.weapon_sprite)


### PR DESCRIPTION
Separates player and vehicle into different classes. Player deals with heath, re-spawning, etc while Vehicle contains and operates the actual sprite

Various other optimizations and bug fixes:
-Vehicle location setter that moves the weapon sprites on the hood too
   -Also fixes bug where weapons stop moving after death
-Added sprite_list.weapons so weapons can be drawn at the same time as everything else
-movement controls gets a reference it it's vehicle in the init rather than in each method
-fixed a bug where vehicle re-spawns with its old velocity by adding a reset_velocity() method