### PR TITLE
Hit indicators

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,6 +9,9 @@ SCREEN_TITLE = "John Deer Clown School"
 TICK_DURATION = 1 / 60
 "Duration of a single update tick of the game, measured in seconds"
 
+HIT_INDICATOR_DURATION = 0.2
+"How long the car flashes for in seconds"
+
 USE_DEBUGGER_TIMING_FIXES = os.environ.get("USE_DEBUGGER_TIMING_FIXES") == "true"
 """
 Locks delta_time to exactly 1/60 of a second regardless of system clock,

--- a/src/ordnances/beam.py
+++ b/src/ordnances/beam.py
@@ -35,11 +35,10 @@ class Beam(Ordnance):
         self,
         sprite: LinkedSprite[Ordnance],
         sprite_lists: SpriteLists,
-        payload_list: list[Ordnance],
         dps: float,
         beam_range: float,
     ):
-        super().__init__(sprite, sprite_lists, payload_list)
+        super().__init__(sprite, sprite_lists)
         self.dps = dps
         self.beam_range = beam_range
         self.muzzle_location = (0, 0, 0)

--- a/src/ordnances/explosion.py
+++ b/src/ordnances/explosion.py
@@ -27,7 +27,6 @@ class Explosion(Ordnance):
         self,
         color: arcade.color,
         sprite_lists: SpriteLists,
-        payload_list: list[Ordnance],
         damage: float,
         explosion_radius: float,
         explosion_rate: float,
@@ -35,7 +34,7 @@ class Explosion(Ordnance):
         explosion_appearance = LinkedSpriteCircle[Explosion](
             explosion_radius, color, soft=False
         )
-        super().__init__(explosion_appearance, sprite_lists, payload_list)
+        super().__init__(explosion_appearance, sprite_lists)
         self.sprite.visible = False
         self.color = color
         self.damage = damage
@@ -63,7 +62,6 @@ class Explosion(Ordnance):
         sub_explosion = SubExplosion(
             sub_explosion_appearance,
             self.sprite_lists,
-            [],
             self.damage,
             self,
             self.explosion_rate,
@@ -86,13 +84,12 @@ class SubExplosion(Ordnance):
         self,
         sprite: LinkedSprite[Ordnance],
         sprite_lists: SpriteLists,
-        payload_list: list[Ordnance],
         damage: float,
         explosion: Explosion,
         explosion_rate: float,
         direction: float,
     ):
-        super().__init__(sprite, sprite_lists, payload_list)
+        super().__init__(sprite, sprite_lists)
         self.damage = damage
         self.explosion = explosion
         self.explosion_rate = explosion_rate

--- a/src/ordnances/ordnance.py
+++ b/src/ordnances/ordnance.py
@@ -36,12 +36,11 @@ class Ordnance:
         self,
         sprite: LinkedSprite[Ordnance],
         sprite_lists: SpriteLists,
-        payload_list: list[Ordnance],
     ):
         self.sprite = sprite
         sprite.owner = self
         self.sprite_lists = sprite_lists
-        self.payload_list = payload_list
+        self.payload_list = []
         self.sprite_rotation_offset = 0
         self.exists = False
 

--- a/src/ordnances/projectile.py
+++ b/src/ordnances/projectile.py
@@ -28,14 +28,13 @@ class Projectile(Ordnance):
         self,
         sprite: LinkedSprite[Ordnance],
         sprite_lists: SpriteLists,
-        payload_list: list[Ordnance],
         damage: float,
         muzzle_location: Tuple[float, float, float],
         speed: float,
         angle_of_motion: float,
         sprite_rotation_offet: float = 0,
     ):
-        super().__init__(sprite, sprite_lists, payload_list)
+        super().__init__(sprite, sprite_lists)
         self.damage = damage
         self.speed = speed
         self.angle_of_motion = angle_of_motion

--- a/src/player.py
+++ b/src/player.py
@@ -19,7 +19,7 @@ class Player:
         self.input = input
         self.vehicle = Vehicle(self, sprite_lists)
         self.vehicle.location = initial_spawn_points[player_index].transform
-        self.alive = True
+        self.alive: bool = True
         self.respawn_time_passed: float = 0
         self.time_to_respawn: float = 5
         self.initial_spawn_points = initial_spawn_points

--- a/src/player.py
+++ b/src/player.py
@@ -19,7 +19,6 @@ class Player:
         self.input = input
         self.vehicle = Vehicle(self, sprite_lists)
         self.vehicle.location = initial_spawn_points[player_index].transform
-        self.player_health = 100
         self.alive = True
         self.respawn_time_passed: float = 0
         self.time_to_respawn: float = 5
@@ -28,28 +27,17 @@ class Player:
     def update(self, delta_time: float):
         self.vehicle.update(delta_time)
         #
-        # Respawn
+        # Wait for Respawn
         #
-        if self.player_health <= 0:
-            self.die(delta_time)
-
-    def take_damage(self, damage: float):
-        self.player_health -= damage
-        if self.player_health < 0:
-            self.player_health = 0
-
-    def die(self, delta_time):
-        self.alive = False
-        self.respawn_time_passed = self.respawn_time_passed + delta_time
-        if self.respawn_time_passed > self.time_to_respawn:
-            self.respawn()
+        if not self.alive:
+            self.respawn_time_passed = self.respawn_time_passed + delta_time
+            if self.respawn_time_passed > self.time_to_respawn:
+                self.respawn()
 
     def respawn(self):
-        self.player_health = 100
         self.alive = True
         self.respawn_time_passed = 0
         chosen_spawn_point = self.initial_spawn_points[
             random.randrange(len(self.initial_spawn_points))
         ].transform
-        self.vehicle.location = chosen_spawn_point
-        self.vehicle.movement.reset_velocity()
+        self.vehicle.respawn(chosen_spawn_point)

--- a/src/playerhud.py
+++ b/src/playerhud.py
@@ -51,11 +51,11 @@ class PlayerHud:
     def update(self):
 
         # changes healthbar length based on current ratio and left sets healthbar
-        if self.player.player_health > 0:
-            ratio = self.player.player_health / 100
+        if self.player.vehicle.health > 0:
+            ratio = self.player.vehicle.health / 100
             self.health_sprite.width = self.health_width * ratio
             self.health_sprite.left = self.hud_x - (self.health_width // 2)
-        elif self.player.player_health <= 0:
+        elif self.player.vehicle.health <= 0:
             self.health_sprite.width = 0.1
             self.health_sprite.left = self.hud_x - (self.health_width // 2)
         # creates respawn timer on player's hud

--- a/src/sprite_lists.py
+++ b/src/sprite_lists.py
@@ -9,24 +9,21 @@ class SpriteLists:
     """
 
     vehicles: arcade.SpriteList
-    weapons: arcade.SpriteList
+    vehicle_attachments: arcade.SpriteList
     ordnance: arcade.SpriteList
-    beams: arcade.SpriteList
     walls: arcade.SpriteList
     huds: arcade.SpriteList
 
     def __init__(self):
         self.vehicles = arcade.SpriteList()
-        self.weapons = arcade.SpriteList()
+        self.vehicle_attachments = arcade.SpriteList()
         self.ordnance = arcade.SpriteList()
-        self.beams = arcade.SpriteList()
         self.walls = arcade.SpriteList()
         self.huds = arcade.SpriteList()
 
     def draw(self):
         self.walls.draw()
         self.vehicles.draw()
-        self.weapons.draw()
+        self.vehicle_attachments.draw()
         self.ordnance.draw()
-        self.beams.draw()
         self.huds.draw()

--- a/src/textures.py
+++ b/src/textures.py
@@ -55,6 +55,8 @@ ROCKET_LAUNCHER = kenney_sheet_1bit.get_texture(43, 9)
 AMMO_CASE = kenney_sheet_1bit.get_texture(43, 9)
 ROCKET = kenney_sheet_1bit.get_texture(33, 21)
 
+FIRE = kenney_sheet_1bit.get_texture(15, 10)
+
 RED_CAR = load_texture("assets/vehicle/red-car-top-view.png")
 
 PLAYER_AVATARS = [

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List
 
 import arcade
 
+from constants import HIT_INDICATOR_DURATION
 from driving.create_drive_modes import create_drive_modes
 from iron_math import (
     get_sprite_location,
@@ -72,7 +73,7 @@ class Vehicle:
 
         if self.hit_indicator:
             self.time_since_hit += delta_time
-            if self.time_since_hit > 0.2:
+            if self.time_since_hit > HIT_INDICATOR_DURATION:
                 self.sprite.alpha = 255
                 self.hit_indicator = False
                 self.time_since_hit = 0
@@ -84,6 +85,7 @@ class Vehicle:
                 self.health = 0
                 self.die()
             self.hit_indicator = True
+            self.time_since_hit = 0
             self.sprite.alpha = 150
 
     def die(self):

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -89,6 +89,8 @@ class Vehicle:
     def die(self):
         self.player.alive = False
         self.sprite_lists.vehicle_attachments.append(self.fire_sprite)
+        self.primary_weapon.deactivate()
+        self.secondary_weapon.deactivate()
 
     def respawn(self, location):
         self.health = 100

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -13,7 +13,7 @@ from iron_math import (
 from linked_sprite import LinkedSprite
 from movement_controls import MovementControls
 from sprite_lists import SpriteLists
-from textures import RED_CAR
+from textures import FIRE, RED_CAR
 from weapons.laser_beam import LaserBeam
 from weapons.machine_gun import MachineGun
 from weapons.rocket_launcher import RocketLauncher
@@ -29,6 +29,7 @@ class Vehicle:
         self.sprite = LinkedSprite[Vehicle](texture=RED_CAR, scale=0.2)
         self.sprite.owner = self
         self.sprite_lists = sprite_lists
+        self.health: float = 100
         self.sprite_lists.vehicles.append(self.sprite)
         self.primary_weapon_transform = (16, 10, 0)
         self.secondary_weapon_transform = (16, -10, 0)
@@ -46,6 +47,7 @@ class Vehicle:
         self._swap_in_weapons()
         self.hit_indicator: bool = False
         self.time_since_hit: float = 0
+        self.fire_sprite = arcade.Sprite(texture=FIRE, scale=3)
         self.drive_mode_index = 0
         self.drive_modes = create_drive_modes(self)
 
@@ -77,9 +79,22 @@ class Vehicle:
 
     def apply_damage(self, damage: float):
         if self.player.alive:
-            self.player.take_damage(damage)
+            self.health -= damage
+            if self.health <= 0:
+                self.health = 0
+                self.die()
             self.hit_indicator = True
             self.sprite.alpha = 150
+
+    def die(self):
+        self.player.alive = False
+        self.sprite_lists.vehicle_attachments.append(self.fire_sprite)
+
+    def respawn(self, location):
+        self.health = 100
+        self.sprite_lists.vehicle_attachments.remove(self.fire_sprite)
+        self.location = location
+        self.movement.reset_velocity()
 
     def _swap_weapons(self):
         # Moves the current secondary weapon to the primary weapon slot and the next weapon on the list becomes the secondary weapon
@@ -105,7 +120,7 @@ class Vehicle:
             self.secondary_weapon_transform,
         )
 
-    def _update_weapon_locations(self):
+    def _update_vehicle_attachment_locations(self):
         move_sprite_relative_to_parent(
             self.primary_weapon.weapon_sprite,
             self.sprite,
@@ -116,6 +131,10 @@ class Vehicle:
             self.sprite,
             self.secondary_weapon_transform,
         )
+        move_sprite_relative_to_parent(
+            self.fire_sprite, self.sprite, (0, 0, -self.radians)
+        )
+        self.fire_sprite.center_y += 15
 
     @property
     def location(self):
@@ -124,7 +143,7 @@ class Vehicle:
     @location.setter
     def location(self, location: tuple[float, float, float]):
         set_sprite_location(self.sprite, location)
-        self._update_weapon_locations()
+        self._update_vehicle_attachment_locations()
 
     # these properties are for the convenience of calling vehicle.center_x rather than vehicle.location[0]
     @property
@@ -134,7 +153,7 @@ class Vehicle:
     @center_x.setter
     def center_x(self, center_x: float):
         self.sprite.center_x = center_x
-        self._update_weapon_locations()
+        self._update_vehicle_attachment_locations()
 
     @property
     def center_y(self):
@@ -143,7 +162,7 @@ class Vehicle:
     @center_y.setter
     def center_y(self, center_y: float):
         self.sprite.center_y = center_y
-        self._update_weapon_locations()
+        self._update_vehicle_attachment_locations()
 
     @property
     def angle(self):
@@ -152,7 +171,7 @@ class Vehicle:
     @angle.setter
     def angle(self, angle: float):
         self.sprite.angle = angle
-        self._update_weapon_locations()
+        self._update_vehicle_attachment_locations()
 
     @property
     def radians(self):
@@ -161,7 +180,7 @@ class Vehicle:
     @radians.setter
     def radians(self, radians: float):
         self.sprite.radians = radians
-        self._update_weapon_locations()
+        self._update_vehicle_attachment_locations()
 
     @property
     def drive_mode(self):

--- a/src/weapons/laser_beam.py
+++ b/src/weapons/laser_beam.py
@@ -49,9 +49,7 @@ class LaserBeam(Weapon):
         beam_appearance = LinkedSpriteSolidColor[Ordnance](
             self.beam_range, 3, arcade.color.RED
         )
-        self.beam = Beam(
-            beam_appearance, self.sprite_lists, [], self.dps, self.beam_range
-        )
+        self.beam = Beam(beam_appearance, self.sprite_lists, self.dps, self.beam_range)
 
     def aim_beam(self):
         if self.beam.exists:

--- a/src/weapons/laser_beam.py
+++ b/src/weapons/laser_beam.py
@@ -41,6 +41,9 @@ class LaserBeam(Weapon):
         super().swap_out()
         self.remove_beam()
 
+    def deactivate(self):
+        self.remove_beam()
+
     def remove_beam(self):
         if self.beam.exists:
             self.beam.remove_sprite()

--- a/src/weapons/machine_gun.py
+++ b/src/weapons/machine_gun.py
@@ -36,7 +36,6 @@ class MachineGun(Weapon):
         bullet = Projectile(
             bullet_appearance,
             self.sprite_lists,
-            [],
             self.bullet_damage,
             get_transformed_location(self.weapon_sprite, self.muzzle_transform),
             self.bullet_speed,

--- a/src/weapons/rocket_launcher.py
+++ b/src/weapons/rocket_launcher.py
@@ -46,7 +46,6 @@ class RocketLauncher(Weapon):
         explosion = Explosion(
             arcade.color.ORANGE_RED,
             self.sprite_lists,
-            [],
             self.explosion_damage,
             self.explosion_radius,
             self.explosion_rate,
@@ -56,12 +55,12 @@ class RocketLauncher(Weapon):
         rocket = Projectile(
             rocket_appearance,
             self.sprite_lists,
-            [explosion],
             self.impact_damage,
             get_transformed_location(self.weapon_sprite, self.muzzle_transform),
             self.rocket_speed,
             self.weapon_sprite.radians,
             sprite_rotation_offet=math.radians(-45),
         )
+        rocket.payload_list.append(explosion)
         # ROCKET texture appears at 45 degree angle. Sprite_rotation_offset compensates for this
         self.time_since_shoot = 0

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -46,3 +46,6 @@ class Weapon:
 
     def swap_out(self):
         self.sprite_lists.vehicle_attachments.remove(self.weapon_sprite)
+
+    def deactivate(self):
+        ...

--- a/src/weapons/weapon.py
+++ b/src/weapons/weapon.py
@@ -30,7 +30,7 @@ class Weapon:
         self.weapon_transform = weapon_transform
         self.time_since_shoot = 100
         self.weapon_sprite = arcade.Sprite(texture=self.weapon_icon, scale=1)
-        self.sprite_lists.weapons.append(self.weapon_sprite)
+        self.sprite_lists.vehicle_attachments.append(self.weapon_sprite)
         self.setup()
 
     def setup(self):
@@ -45,4 +45,4 @@ class Weapon:
         ...
 
     def swap_out(self):
-        self.sprite_lists.weapons.remove(self.weapon_sprite)
+        self.sprite_lists.vehicle_attachments.remove(self.weapon_sprite)


### PR DESCRIPTION
Main purposes
-Vehicle's alpha flashes for 0.2 seconds when hit
-Vehicle catches fire to indicate it is dead and waiting to re-spawn

Other optimizations and bug fixes
-moved heath and damage taking to vehicle. This makes sense and cleans up the damage taking process
-Ordnance no longer need to be passed an empty payload list to initialize
-implemented bug fix to stop beams hanging around when vehicle dies
-changed sprite_lists.weapons to sprite_lists.vehicle_attachments to include weapons as well as anything else that moves around attached to the car, like the fire sprite