### PR TITLE
Move spawn point away from wall

### DIFF
--- a/assets/arenas/debug.tmx
+++ b/assets/arenas/debug.tmx
@@ -27,7 +27,7 @@
     <property name="initial_spawn_for_player" value="0"/>
    </properties>
   </object>
-  <object id="22" template="tiled_templates/spawn_point.tx" class="SpawnPoint" x="390.16" y="342.738" rotation="90.3662"/>
+  <object id="22" class="SpawnPoint" gid="1" x="390.16" y="342.738" rotation="90.3662"/>
   <object id="25" class="PatrolWaypoint" x="668.667" y="322">
    <properties>
     <property name="next" type="object" value="26"/>

--- a/assets/arenas/default.tmx
+++ b/assets/arenas/default.tmx
@@ -27,7 +27,7 @@
     <property name="initial_spawn_for_player" value="0"/>
    </properties>
   </object>
-  <object id="22" template="tiled_templates/spawn_point.tx" class="SpawnPoint" x="390.16" y="342.738" rotation="90.3662"/>
+  <object id="22" class="SpawnPoint" gid="1" x="390.16" y="342.738" rotation="90.3662"/>
   <object id="25" class="PatrolWaypoint" x="668.667" y="322">
    <properties>
     <property name="next" type="object" value="26"/>

--- a/src/arena/arena_loader.py
+++ b/src/arena/arena_loader.py
@@ -46,7 +46,10 @@ def load_arena_by_name(name: str) -> Arena:
                 "initial_spawn_for_player"
             )
             initial_spawn_for_player = None
-            if initial_spawn_for_player_str is not None:
+            if (
+                initial_spawn_for_player_str is not None
+                and initial_spawn_for_player_str != ""
+            ):
                 initial_spawn_for_player = int(initial_spawn_for_player_str)
 
             spawn_point = SpawnPoint(transform, initial_spawn_for_player)


### PR DESCRIPTION
Turns out this was due to a pytiled-parser bug with templates.  Fix is to not use templates.  I spoke with the devs on Discord, they're working on a fix tonight.  But we don't need to wait for that.